### PR TITLE
Always dev-wf-ui otherwise we don't have the most recent version in product

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -130,7 +130,6 @@ pipeline {
       when {
         allOf {
           branch 'master'
-          expression { return currentBuild.currentResult == 'SUCCESS' || params.deployScreenshots || manualDeploy }
         }
       }
       steps {


### PR DESCRIPTION
we always deploy. at the moment there is not dev wf ui 10.0.0-snapshot because flaky test.

we changed this already in engine cockpit.

instead of allOf {
 branch 'master'
}

you should check if this is the master or a releaes branch. otherwise you always need to change this file when you create a new release branch. please change this. see build in engine-cockpit.