### PR TITLE
XIVY-9397 Always provide root-relative url as originalUrl

### DIFF
--- a/dev-workflow-ui/src/ch/ivyteam/workflowui/util/UrlUtil.java
+++ b/dev-workflow-ui/src/ch/ivyteam/workflowui/util/UrlUtil.java
@@ -16,7 +16,7 @@ public class UrlUtil {
 
   public static String evalOriginalPage() {
     return evalOriginalUrl()
-    		.replace("/frame.xhtml", "/allTasks.xhtml");
+             .replace("/frame.xhtml", "/allTasks.xhtml");
   }
 
   public static HttpServletRequest getHttpServletRequest() {


### PR DESCRIPTION
So that it is always possible to redirect from anywhere in the hole ivy system to the original url. Because I want to pick-up this original url for OAuth2 logins. So that I can redirect to this URL after login, which will be redirected from a complete other place (OAuth2Servlet).