### PR TITLE
Fix deploying on master

### DIFF
--- a/maven/image-validation/pom.xml
+++ b/maven/image-validation/pom.xml
@@ -9,6 +9,7 @@
   </parent>
 
   <artifactId>dev-workflow-ui-image-validation</artifactId>
+  <packaging>pom</packaging>
 
   <properties>
     <test.target.dir>${project.basedir}/../../dev-workflow-ui-web-test/target/</test.target.dir>


### PR DESCRIPTION
Fails because `[ERROR] Failed to execute goal org.apache.maven.plugins:maven-install-plugin:2.4:install (default-install) on project dev-workflow-ui-image-validation: The packaging for this project did not assign a file to the build artifact`