### PR TITLE
XIVY-9722 Refresh iframe only refreshes the dialog and not the process

### DIFF
--- a/dev-workflow-ui/webContent/view/frame.xhtml
+++ b/dev-workflow-ui/webContent/view/frame.xhtml
@@ -44,8 +44,16 @@
             if (newHref !== lastDispatched) {
               callback(newHref, iframe);
               lastDispatched = newHref;
+              updateHistory(newHref);
             }
           };
+
+          var updateHistory = function(newHref) {
+            var newHrefUrl = new URL(newHref);
+            var historyUrl = new URL(window.location);
+            historyUrl.searchParams.set('taskUrl', newHrefUrl.pathname + newHrefUrl.search);
+            history.replaceState({}, "", historyUrl);
+          }
 
           var unloadHandler = function() {
             // Timeout needed because the URL changes immediately after


### PR DESCRIPTION
- Replace the browser history with the current dialog url, so a refresh loads the dialog url in the iframe instead of restart the process

**Before:**
![iframe-refresh-bug](https://user-images.githubusercontent.com/42733123/196408830-1a9852df-c533-445b-8689-96892664e2a1.gif)
**After:**
![iframe-refresh-fix](https://user-images.githubusercontent.com/42733123/196409045-1bb1276b-9e55-4bf4-a104-24b4ef4683ab.gif)
