### PR TITLE
XIVY-11209 Task responsible show display name instead of abbreviation

### DIFF
--- a/dev-workflow-ui/src/ch/ivyteam/workflowui/user/UserComponentModel.java
+++ b/dev-workflow-ui/src/ch/ivyteam/workflowui/user/UserComponentModel.java
@@ -13,8 +13,13 @@ public class UserComponentModel {
   }
 
   public UserComponentModel(IActivator user) {
-    this.name = user.name();
-    this.cssIcon = getCssIcon(user.get());
+    var securityMember = user.get();
+    if (securityMember != null) {
+      this.name = securityMember.getDisplayName();
+    } else {
+      this.name = user.name();
+    }
+    this.cssIcon = getCssIcon(securityMember);
   }
 
   private static String getCssIcon(ISecurityMember user) {


### PR DESCRIPTION
Instead of:
![image](https://user-images.githubusercontent.com/42733123/232478235-8ea6e5b2-f6dd-4d8d-bd3e-3f9c415409d2.png)
Show:
![image](https://user-images.githubusercontent.com/42733123/232478277-742142d7-87a2-4631-89d7-8001ab05938e.png)
