### PR TITLE
XIVY-11209 Task responsible show display name instead of abbreviation > R10

### DIFF
--- a/dev-workflow-ui/src/ch/ivyteam/workflowui/user/UserComponentModel.java
+++ b/dev-workflow-ui/src/ch/ivyteam/workflowui/user/UserComponentModel.java
@@ -13,8 +13,13 @@ public class UserComponentModel {
   }
 
   public UserComponentModel(IActivator user) {
-    this.name = user.name();
-    this.cssIcon = getCssIcon(user.get());
+    var securityMember = user.get();
+    if (securityMember != null) {
+      this.name = securityMember.getDisplayName();
+    } else {
+      this.name = user.name();
+    }
+    this.cssIcon = getCssIcon(securityMember);
   }
 
   private static String getCssIcon(ISecurityMember user) {


### PR DESCRIPTION
Same as on master: https://github.com/axonivy/dev-workflow-ui/pull/197