### PR TITLE
XIVY-11246 Fix npe after user switch if orignal url is case/task detail

### DIFF
--- a/dev-workflow-ui-web-test/pom.xml
+++ b/dev-workflow-ui-web-test/pom.xml
@@ -103,7 +103,7 @@
               <goal>copy-resources</goal>
             </goals>
             <configuration>
-              <outputDirectory>${basedir}/../maven/config/target/ivyEngine/webapps/workflow/</outputDirectory>
+              <outputDirectory>${basedir}/../maven/config/target/ivyEngine/webapps/dev-workflow-ui/</outputDirectory>
               <resources>
                 <resource>
                   <directory>${basedir}/../dev-workflow-ui/target/</directory>

--- a/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebDocuScreenshots.java
+++ b/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebDocuScreenshots.java
@@ -77,7 +77,7 @@ public class WebDocuScreenshots {
     takeScreenshot("workflow-ui-signals", new Dimension(SCREENSHOT_WIDTH, 800));
     $(By.id("boundarySignalsTable:0:sendSignalIcon")).shouldBe(visible).click();
 
-    WorkflowUiUtil.startTestCaseMap("0cf1f054-a4ad-4b2b-bcf1-c9c34ec0a2ab.icm");
+    WorkflowUiUtil.startTestCaseMap();
     openView("cases.xhtml");
     $(".detail-btn").shouldBe(visible).click();
     takeScreenshot("workflow-ui-caseMap", new Dimension(SCREENSHOT_WIDTH, 800));

--- a/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestCaseMapIT.java
+++ b/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestCaseMapIT.java
@@ -34,18 +34,16 @@ public class WebTestCaseMapIT {
   void beforeEach() {
     startTestProcess("175461E47A870BF8/makeAdminUser.ivp");
     loginDeveloper();
-    startTestCaseMap("0cf1f054-a4ad-4b2b-bcf1-c9c34ec0a2ab.icm");
-    $(By.id("form:proceed")).shouldBe(visible).click();
+    startTestCaseMap();
   }
 
   @Test
   public void caseDetails() {
-    startTestCaseMap("0cf1f054-a4ad-4b2b-bcf1-c9c34ec0a2ab.icm");
     openView("cases.xhtml");
     $(".detail-btn").shouldBe(visible).click();
 
     $(By.id("creatorUser:userName")).shouldBe(exactText("DeveloperTest"));
-    $(By.id("caseState")).shouldBe(exactText("OPEN (CREATED)"));
+    $(By.id("caseState")).shouldBe(exactText("OPEN (RUNNING)"));
 
     $(".case-map-column").shouldHave(text("stage1"));
     $(".process-flow").shouldBe(visible);

--- a/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestCleanup.java
+++ b/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestCleanup.java
@@ -4,12 +4,14 @@ import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.loginD
 import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.loginFromTable;
 import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.openView;
 import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.startTestProcess;
+import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.viewUrl;
 import static com.codeborne.selenide.Condition.cssClass;
 import static com.codeborne.selenide.Condition.disabled;
 import static com.codeborne.selenide.Condition.enabled;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.Selenide.open;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -59,7 +61,7 @@ public class WebTestCleanup {
     startTestProcess("1783B19164F69B78/designerEmbedded.ivp");
 
     loginFromTable("testuser");
-    openView("cleanup.xhtml");
+    open(viewUrl("cleanup.xhtml"));
     $(By.id("menuform:sr_home")).shouldHave(cssClass("active-menuitem"));
 
     loginDeveloper();

--- a/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestHomeRedirect.java
+++ b/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestHomeRedirect.java
@@ -1,27 +1,28 @@
 package ch.ivyteam.ivy.project.workflow.webtest;
 
-import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.openView;
+import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.loginFromTable;
+import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.startTestProcess;
+import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.viewUrl;
 import static com.codeborne.selenide.Condition.cssClass;
 import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.Selenide.open;
 
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 
 import com.axonivy.ivy.webtest.IvyWebTest;
 
-import ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil;
-
 @IvyWebTest
 public class WebTestHomeRedirect {
 
   @Test
   public void homepageRedirect() {
-    WorkflowUiUtil.loginFromTable("testuser");
-    WorkflowUiUtil.startTestProcess("1750C5211D94569D/cleanupSession.ivp");
+    loginFromTable("testuser");
+    startTestProcess("1750C5211D94569D/cleanupSession.ivp");
 
-    openView("home.xhtml");
+    open(viewUrl("home.xhtml"));
     $(By.id("menuform:sr_starts")).shouldHave(cssClass("active-menuitem"));
-    openView("home.xhtml");
+    open(viewUrl("home.xhtml"));
     $(By.id("menuform:sr_starts")).shouldNotHave(cssClass("active-menuitem"));
     $(By.id("menuform:sr_home")).shouldHave(cssClass("active-menuitem"));
   }

--- a/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestIntermediateEventsIT.java
+++ b/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestIntermediateEventsIT.java
@@ -4,11 +4,13 @@ import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.loginD
 import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.loginFromTable;
 import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.openView;
 import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.startTestProcess;
+import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.viewUrl;
 import static com.codeborne.selenide.Condition.cssClass;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selectors.byText;
 import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.Selenide.open;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,7 +37,7 @@ public class WebTestIntermediateEventsIT {
   public void adminOnly() {
     openView("home.xhtml");
     loginFromTable("testuser");
-    openView("intermediateEvents.xhtml");
+    open(viewUrl("intermediateEvents.xhtml"));
     $(By.id("menuform:sr_home")).shouldHave(cssClass("active-menuitem"));
 
     loginDeveloper();

--- a/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestSignalsIT.java
+++ b/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestSignalsIT.java
@@ -4,11 +4,13 @@ import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.loginD
 import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.loginFromTable;
 import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.openView;
 import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.startTestProcess;
+import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.viewUrl;
 import static com.codeborne.selenide.Condition.cssClass;
 import static com.codeborne.selenide.Condition.enabled;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.Selenide.open;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,7 +38,7 @@ public class WebTestSignalsIT {
   @Test
   public void testSignalAdminOnly() {
     loginFromTable("testuser");
-    openView("signals.xhtml");
+    open(viewUrl("signals.xhtml"));
     $(By.id("menuform:sr_home")).shouldHave(cssClass("active-menuitem"));
 
     loginDeveloper();

--- a/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/util/WorkflowUiUtil.java
+++ b/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/util/WorkflowUiUtil.java
@@ -1,18 +1,21 @@
 package ch.ivyteam.ivy.project.workflow.webtest.util;
 
+import static com.axonivy.ivy.webtest.engine.EngineUrl.createCaseMapUrl;
+import static com.axonivy.ivy.webtest.engine.EngineUrl.createProcessUrl;
 import static com.axonivy.ivy.webtest.engine.EngineUrl.createStaticViewUrl;
+import static com.codeborne.selenide.Condition.exist;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selectors.byText;
 import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.Selenide.open;
+import static com.codeborne.selenide.Selenide.webdriver;
+import static com.codeborne.selenide.WebDriverConditions.urlContaining;
 
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
-
-import com.axonivy.ivy.webtest.engine.EngineUrl;
-import com.codeborne.selenide.Selenide;
-import com.codeborne.selenide.WebDriverConditions;
+import org.openqa.selenium.By;
 
 import ch.ivyteam.ivy.security.IUser;
 import ch.ivyteam.workflowui.util.UserUtil;
@@ -23,25 +26,22 @@ public class WorkflowUiUtil {
   }
 
   public static void startTestProcess(String pathToIvp) {
-    var url = EngineUrl.createProcessUrl("/dev-workflow-ui-test-data/" + pathToIvp);
-    System.out.println(url);
-    Selenide.open(url);
-    assertCurrentUrlContains("starts.xhtml");
+    open(createProcessUrl("/dev-workflow-ui-test-data/" + pathToIvp));
+    assertCurrentUrlContains("end.xhtml");
   }
 
-  public static void startTestCaseMap(String path) {
-    var url = EngineUrl.createCaseMapUrl("/dev-workflow-ui-test-data/" + path);
-    System.out.println(url);
-    Selenide.open(url);
-    assertCurrentUrlContains("starts.xhtml");
+  public static void startTestCaseMap() {
+    open(createCaseMapUrl("/dev-workflow-ui-test-data/0cf1f054-a4ad-4b2b-bcf1-c9c34ec0a2ab.icm"));
+    $(By.id("form:proceed")).shouldBe(visible).click();
+    assertCurrentUrlContains("end.xhtml");
   }
 
   public static void openView(String page) {
-    Selenide.open(viewUrl(page));
+    open(viewUrl(page));
     assertCurrentUrlContains(page);
   }
 
-  private static String viewUrl(String page) {
+  public static String viewUrl(String page) {
     var securityContext = System.getProperty("test.integrated.workflow");
     if (StringUtils.isNotEmpty(securityContext)) {
       var engineUri = System.getProperty("test.engine.url");
@@ -55,7 +55,7 @@ public class WorkflowUiUtil {
   }
 
   public static void assertCurrentUrlContains(String contains) {
-    WebDriverConditions.currentFrameUrlContaining(contains);
+    webdriver().shouldHave(urlContaining(contains));
   }
 
   public static List<IUser> getUsers() {
@@ -63,9 +63,9 @@ public class WorkflowUiUtil {
   }
 
   public static void loginFromTable(String username) {
-    Selenide.open(viewUrl("loginTable.xhtml"));
-    $(byText(username)).should(visible).click();
-    assertCurrentUrlContains("home.xhtml");
+    open(viewUrl("loginTable.xhtml"));
+    $(By.id("loginTable")).find(byText(username)).should(visible).click();
+    $(By.id("loginTable")).shouldNot(exist);
   }
 
   public static void loginDeveloper() {
@@ -73,13 +73,12 @@ public class WorkflowUiUtil {
   }
 
   public static void customLogin(String username, String password) {
-    Selenide.open(viewUrl("login.xhtml"));
+    open(viewUrl("login.xhtml"));
     $("#loginForm\\:userName").clear();
     $("#loginForm\\:userName").sendKeys(username);
     $("#loginForm\\:password").clear();
     $("#loginForm\\:password").sendKeys(password);
     $("#loginForm\\:login").shouldBe(visible).click();
-    assertCurrentUrlContains("home.xhtml");
   }
 
   public static void logout() {

--- a/dev-workflow-ui/src/ch/ivyteam/workflowui/login/LoginIvyDevWfBean.java
+++ b/dev-workflow-ui/src/ch/ivyteam/workflowui/login/LoginIvyDevWfBean.java
@@ -2,6 +2,7 @@ package ch.ivyteam.workflowui.login;
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -15,11 +16,12 @@ import org.primefaces.event.SelectEvent;
 
 import ch.ivyteam.ivy.security.ISecurityContext;
 import ch.ivyteam.ivy.security.IUser;
+import ch.ivyteam.ivy.security.identity.core.auth.oauth2.OAuth2Url;
 import ch.ivyteam.ivy.security.identity.spi.IdentityProvider;
 import ch.ivyteam.ivy.security.identity.spi.auth.oauth2.OAuth2Authenticator;
-import ch.ivyteam.ivy.security.identity.core.auth.oauth2.OAuth2Url;
 import ch.ivyteam.ivy.security.restricted.ISecurityContextInternal;
 import ch.ivyteam.workflowui.login.LoginTableIvyDevWfBean.User;
+import ch.ivyteam.workflowui.util.UrlUtil;
 import ch.ivyteam.workflowui.util.UserUtil;
 
 @ManagedBean
@@ -42,6 +44,10 @@ public class LoginIvyDevWfBean {
 
   public void setOriginalUrl(String originalUrl) {
     this.originalUrl = originalUrl;
+  }
+
+  public String getOriginalPage() {
+    return URLEncoder.encode(UrlUtil.evalOriginalPage(), StandardCharsets.UTF_8);
   }
 
   private void login(User user) {
@@ -68,14 +74,6 @@ public class LoginIvyDevWfBean {
 
   public void redirectIfNotAdmin() {
     UserUtil.redirectIfNotAdmin();
-  }
-
-  public void redirectToLoginForm() {
-    LoginUtil.redirectToLoginForm();
-  }
-
-  public void redirectToLoginTable() {
-    LoginUtil.redirectToLoginTable();
   }
 
   public String getRoles(IUser user) {

--- a/dev-workflow-ui/src/ch/ivyteam/workflowui/login/LoginUtil.java
+++ b/dev-workflow-ui/src/ch/ivyteam/workflowui/login/LoginUtil.java
@@ -1,5 +1,8 @@
 package ch.ivyteam.workflowui.login;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
 import javax.faces.application.FacesMessage;
 import javax.faces.context.FacesContext;
 
@@ -40,12 +43,12 @@ public class LoginUtil {
   }
 
   public static void redirectToLoginForm() {
-    String origin = UrlUtil.evalOriginalPage();
+    String origin = URLEncoder.encode(UrlUtil.evalOriginalPage(), StandardCharsets.UTF_8);
     RedirectUtil.redirect("login.xhtml?originalUrl=" + origin);
   }
 
   public static void redirectToLoginTable() {
-    String origin = UrlUtil.evalOriginalPage();
+    String origin = URLEncoder.encode(UrlUtil.evalOriginalPage(), StandardCharsets.UTF_8);
     RedirectUtil.redirect("loginTable.xhtml?originalUrl=" + origin);
   }
 }

--- a/dev-workflow-ui/webContent/includes/template/template.xhtml
+++ b/dev-workflow-ui/webContent/includes/template/template.xhtml
@@ -56,16 +56,16 @@
                   </p:link>
                 </li>
                 <li>
-                  <p:commandLink id="loginTableBtn" actionListener="#{loginIvyDevWfBean.redirectToLoginTable}" rendered="#{engineModeIvyDevWfBean.demoOrDesigner}">
+                  <p:link id="loginTableBtn" href="loginTable.xhtml?originalUrl=#{loginIvyDevWfBean.originalPage}" rendered="#{engineModeIvyDevWfBean.demoOrDesigner}">
                     <i class="si si-lg si-multiple-neutral-1"></i>
                     <span>Switch user</span>
-                  </p:commandLink>
+                  </p:link>
                 </li>
                 <li>
-                  <p:commandLink id="loginFormBtn" actionListener="#{loginIvyDevWfBean.redirectToLoginForm}">
+                  <p:link id="loginFormBtn" href="login.xhtml?originalUrl=#{loginIvyDevWfBean.originalPage}">
                     <i class="si si-lg si-login-3"></i>
                     <span>Login</span>
-                  </p:commandLink>
+                  </p:link>
                 </li>
                 <li>
                   <p:commandLink id="sessionLogoutBtn" actionListener="#{loginIvyDevWfBean.logout}"


### PR DESCRIPTION
The problem is not that the case/task id is not on the parameter, the problem is that if you do a redirect to the login page, then a POST request is first triggered (without any query params). The original URL is then evaluated from this POST request instead of the inital page request.