### PR TITLE
Improve deploy to engine (10.0)

### DIFF
--- a/maven/deploy/pom.xml
+++ b/maven/deploy/pom.xml
@@ -15,6 +15,8 @@
   </parent>
 
   <properties>
+    <skipDeployToEngine>true</skipDeployToEngine>
+    <deployToEngineUrl>http://localhost</deployToEngineUrl>
     <deployApplicationName>dev-workflow-ui-${user.name}</deployApplicationName>
   </properties>
 
@@ -44,14 +46,15 @@
         <executions>
           <execution>
             <id>test.app.deploy</id>
-            <phase>verify</phase>
+            <phase>deploy</phase>
             <goals>
               <goal>deploy-to-engine</goal>
             </goals>
             <configuration>
+              <skipDeploy>${skipDeployToEngine}</skipDeploy>
               <deployMethod>HTTP</deployMethod>
               <deployServerId>axonivy.engine</deployServerId>
-              <deployEngineUrl>https://nightly-10.demo.ivyteam.io</deployEngineUrl>
+              <deployEngineUrl>${deployToEngineUrl}</deployEngineUrl>
               <deployFile>${project.build.directory}/${project.artifactId}-${project.version}.zip</deployFile>
               <deployToEngineApplication>${deployApplicationName}</deployToEngineApplication>
               <deployTestUsers>true</deployTestUsers>


### PR DESCRIPTION
- Own stage for deploy to engine
- Do not fail build if deployment to engine fails (only stage fails)
- Make deployToEngineUrl configurable
- Show demo link only if deployment works
- Demo link is now always correct (application name truncated)