### PR TITLE
XIVY-13226 fix flickering when frame content gets unloaded

### DIFF
--- a/dev-workflow-ui/webContent/view/frame.xhtml
+++ b/dev-workflow-ui/webContent/view/frame.xhtml
@@ -58,6 +58,7 @@
             // Timeout needed because the URL changes immediately after
             // the `unload` event is dispatched.
             setTimeout(dispatchChange, 0);
+            iframe.style.visibility = 'hidden';
           };
 
           function attachUnload() {

--- a/dev-workflow-ui/webContent/view/frame.xhtml
+++ b/dev-workflow-ui/webContent/view/frame.xhtml
@@ -72,7 +72,6 @@
             attachUnload();
             // Just in case the change wasn't dispatched during the unload event...
             dispatchChange();
-            iframe.style.visibility = 'visible';
           });
 
           attachUnload();
@@ -119,6 +118,9 @@
             var newPage = checkAndReturnUrl(newURL, originPage);
             if (newPage) {
               window.location = newPage;
+            }
+            else {
+              iframe.style.visibility = 'visible';
             }
           }
         });


### PR DESCRIPTION
![flicker](https://github.com/axonivy/dev-workflow-ui/assets/93579455/dd2bfaac-cc68-4295-86fe-17e1eb339f4e)

this fix was already there, see https://github.com/axonivy/dev-workflow-ui/pull/149/files

fix does not work for safari...
