### PR TITLE
XIVY-13150 implement notification actions

### DIFF
--- a/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestNotification.java
+++ b/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestNotification.java
@@ -23,7 +23,7 @@ class WebTestNotification {
 
   @Test
   void markAsRead() {
-    startTestProcess("1750C5211D94569D/createNotification.ivp");
+    createNotification();
 
     $(By.id("showNotifications")).should(visible).click();
 
@@ -39,8 +39,8 @@ class WebTestNotification {
 
   @Test
   void markAllAsRead() {
-    startTestProcess("1750C5211D94569D/createNotification.ivp");
-    startTestProcess("1750C5211D94569D/createNotification.ivp");
+    createNotification();
+    createNotification();
 
     $(By.id("showNotifications")).should(visible).click();
 
@@ -55,8 +55,8 @@ class WebTestNotification {
 
   @Test
   void hideAll() {
-    startTestProcess("1750C5211D94569D/createNotification.ivp");
-    startTestProcess("1750C5211D94569D/createNotification.ivp");
+    createNotification();
+    createNotification();
 
     $(By.id("showNotifications")).should(visible).click();
 
@@ -68,5 +68,27 @@ class WebTestNotification {
     $(By.id("notificationForm:notifications:0:notificationMarkAsRead")).should(not(visible));
     $(By.id("notificationForm:notifications:1:notificationMarkAsRead")).should(not(visible));
     $(By.id("no-notifications")).should(visible);
+  }
+
+  @Test
+  void info() {
+    createNotification();
+
+    $(By.id("showNotifications")).should(visible).click();
+    $(By.id("notificationForm:notifications:0:notificationMessage")).should(visible).click();
+    $(By.id("taskDetail")).should(visible);
+  }
+
+  @Test
+  void run() {
+    createNotification();
+
+    $(By.id("showNotifications")).should(visible).click();
+    $(By.id("notificationForm:notifications:0:notificationRunAction")).should(visible).click();
+    $(By.id("iFrameForm:frameTaskName")).should(visible);
+  }
+
+  private void createNotification() {
+    startTestProcess("1750C5211D94569D/createNotification.ivp");
   }
 }

--- a/dev-workflow-ui/src/ch/ivyteam/workflowui/notification/NotificationActionDTO.java
+++ b/dev-workflow-ui/src/ch/ivyteam/workflowui/notification/NotificationActionDTO.java
@@ -1,0 +1,14 @@
+package ch.ivyteam.workflowui.notification;
+
+import ch.ivyteam.ivy.model.value.WebLink;
+import ch.ivyteam.ivy.notification.web.WebNotificationAction;
+
+public record NotificationActionDTO(WebNotificationAction.Type type, WebLink link) {
+  public String icon() {
+    return "si-controls-play";
+  }
+
+  public String tooltip() {
+    return "Run";
+  }
+}

--- a/dev-workflow-ui/src/ch/ivyteam/workflowui/notification/NotificationDto.java
+++ b/dev-workflow-ui/src/ch/ivyteam/workflowui/notification/NotificationDto.java
@@ -3,6 +3,7 @@ package ch.ivyteam.workflowui.notification;
 import java.util.Date;
 
 import ch.ivyteam.ivy.notification.web.WebNotification;
+import ch.ivyteam.ivy.notification.web.WebNotificationAction;
 
 public class NotificationDto {
 
@@ -14,6 +15,20 @@ public class NotificationDto {
 
   public String getMessage() {
     return notification.message();
+  }
+
+  public WebNotificationAction getInfoAction() {
+    return notification.actions().stream()
+            .filter(action -> action.type().equals(WebNotificationAction.Type.INFO))
+            .findAny()
+            .orElse(null);
+  }
+
+  public WebNotificationAction getRunAction() {
+    return notification.actions().stream()
+            .filter(action -> action.type().equals(WebNotificationAction.Type.RUN))
+            .findAny()
+            .orElse(null);
   }
 
   public Date getCreatedAt() {

--- a/dev-workflow-ui/src/ch/ivyteam/workflowui/notification/NotificationDto.java
+++ b/dev-workflow-ui/src/ch/ivyteam/workflowui/notification/NotificationDto.java
@@ -1,34 +1,34 @@
 package ch.ivyteam.workflowui.notification;
 
 import java.util.Date;
+import java.util.List;
 
+import ch.ivyteam.ivy.model.value.WebLink;
 import ch.ivyteam.ivy.notification.web.WebNotification;
 import ch.ivyteam.ivy.notification.web.WebNotificationAction;
 
 public class NotificationDto {
 
   private final WebNotification notification;
+  private final WebLink info;
+  private final List<NotificationActionDTO> actions;
 
   public NotificationDto(WebNotification notification) {
     this.notification = notification;
+    this.info = info();
+    this.actions = actions();
   }
 
   public String getMessage() {
     return notification.message();
   }
 
-  public WebNotificationAction getInfoAction() {
-    return notification.actions().stream()
-            .filter(action -> action.type().equals(WebNotificationAction.Type.INFO))
-            .findAny()
-            .orElse(null);
+  public WebLink getInfo() {
+    return info;
   }
 
-  public WebNotificationAction getRunAction() {
-    return notification.actions().stream()
-            .filter(action -> action.type().equals(WebNotificationAction.Type.RUN))
-            .findAny()
-            .orElse(null);
+  public List<NotificationActionDTO> getActions() {
+    return actions;
   }
 
   public Date getCreatedAt() {
@@ -48,5 +48,24 @@ public class NotificationDto {
 
   public boolean isRead() {
     return notification.isRead();
+  }
+
+  private WebLink info() {
+    var infoAction = notification.actions().stream()
+            .filter(action -> action.type().equals(WebNotificationAction.Type.INFO))
+            .findAny()
+            .orElse(null);
+    return infoAction != null ? infoAction.link() : null;
+  }
+
+  private List<NotificationActionDTO> actions() {
+    return notification.actions().stream()
+            .filter(action -> !action.type().equals(WebNotificationAction.Type.INFO))
+            .map(action -> toNotificationActionDTO(action))
+            .toList();
+  }
+
+  private NotificationActionDTO toNotificationActionDTO(WebNotificationAction action) {
+    return new NotificationActionDTO(action.type(), action.link());
   }
 }

--- a/dev-workflow-ui/webContent/includes/template/notifications.xhtml
+++ b/dev-workflow-ui/webContent/includes/template/notifications.xhtml
@@ -37,23 +37,31 @@
         <p:dataScroller id="notifications" lazy="true" styleClass="notification-scroll" value="#{notificationBean.dataModel}" var="notification" chunkSize="20" mode="inline">
           <div class="#{notification.style} notification-container">
             <div class="p-d-flex p-jc-between">
-              <h:outputLink id="notificationMessage" value="#{notification.infoAction.link()}" styleClass="notification-message">
-                <h:outputText value="#{notification.message}"/>
+              <h:outputText rendered="#{notification.info == null}" value="#{notification.message}" escape="false"/>
+              <h:outputLink rendered="#{notification.info != null}" id="notificationMessage" value="#{notification.info}" styleClass="notification-message">
+                <h:outputText value="#{notification.message}" escape="false"/>
               </h:outputLink>
               <p:tooltip for="notificationMessage" value="Info" />
 
               <div class="p-d-flex notification-action-container">
-                <h:outputLink id="notificationRunAction" value="#{notification.runAction.link()}" rendered="#{notification.runAction != null}">
-                  <i class="notification-action si si-controls-play p-mr-1 " />
-                </h:outputLink>
-                <p:tooltip for="notificationRunAction" value="Run" />
-                <p:commandLink id="notificationMarkAsRead" process="@this" rendered="#{!notification.read}" actionListener="#{notificationBean.markAsRead(notification)}" update="notifications unreadNotifications">
-                  <i class="notification-action si si-check-circle-1 p-mr-1 " />
-                </p:commandLink>
-                <p:tooltip for="notificationMarkAsRead" value="Mark as read" />
+                <div class="p-d-flex">
+                  <ui:repeat var="action" value="#{notification.actions}">
+                    <h:outputLink id="notificationAction" value="#{action.link()}">
+                      <i class="notification-action si #{action.icon()} p-mr-1 " />
+                    </h:outputLink>
+                    <p:tooltip for="notificationAction" value="#{action.tooltip()}" />
+                  </ui:repeat>
+                </div>
+                
+                <h:panelGroup styleClass="p-d-flex notification-mark-as-read" rendered="#{!notification.read}">
+                  <p:commandLink id="notificationMarkAsRead" process="@this" actionListener="#{notificationBean.markAsRead(notification)}" update="notifications unreadNotifications">
+                    <i class="notification-action si si-check-circle-1 p-mr-1 " />
+                  </p:commandLink>
+                  <p:tooltip for="notificationMarkAsRead" value="Mark as read" />
+                </h:panelGroup>
               </div>
             </div>
-
+            
             <div>
               <h:outputText value="#{notification.createdAt}" style="font-size: 0.75em;">
                 <f:convertDateTime type="both" dateStyle="medium" timeStyle="short" />

--- a/dev-workflow-ui/webContent/includes/template/notifications.xhtml
+++ b/dev-workflow-ui/webContent/includes/template/notifications.xhtml
@@ -37,11 +37,18 @@
         <p:dataScroller id="notifications" lazy="true" styleClass="notification-scroll" value="#{notificationBean.dataModel}" var="notification" chunkSize="20" mode="inline">
           <div class="#{notification.style} notification-container">
             <div class="p-d-flex p-jc-between">
-              <h:outputText id="notificationMessage" value="#{notification.message}" escape="false"/>
+              <h:outputLink id="notificationMessage" value="#{notification.infoAction.link()}" styleClass="notification-message">
+                <h:outputText value="#{notification.message}"/>
+              </h:outputLink>
+              <p:tooltip for="notificationMessage" value="Info" />
 
-              <div class="p-d-flex">
+              <div class="p-d-flex notification-action-container">
+                <h:outputLink id="notificationRunAction" value="#{notification.runAction.link()}" rendered="#{notification.runAction != null}">
+                  <i class="notification-action si si-controls-play p-mr-1 " />
+                </h:outputLink>
+                <p:tooltip for="notificationRunAction" value="Run" />
                 <p:commandLink id="notificationMarkAsRead" process="@this" rendered="#{!notification.read}" actionListener="#{notificationBean.markAsRead(notification)}" update="notifications unreadNotifications">
-                  <i class="notification-button si si-check-circle-1 p-mr-1 " />
+                  <i class="notification-action si si-check-circle-1 p-mr-1 " />
                 </p:commandLink>
                 <p:tooltip for="notificationMarkAsRead" value="Mark as read" />
               </div>

--- a/dev-workflow-ui/webContent/includes/template/notifications.xhtml
+++ b/dev-workflow-ui/webContent/includes/template/notifications.xhtml
@@ -52,7 +52,7 @@
                     <p:tooltip for="notificationAction" value="#{action.tooltip()}" />
                   </ui:repeat>
                 </div>
-                
+
                 <h:panelGroup styleClass="p-d-flex notification-mark-as-read" rendered="#{!notification.read}">
                   <p:commandLink id="notificationMarkAsRead" process="@this" actionListener="#{notificationBean.markAsRead(notification)}" update="notifications unreadNotifications">
                     <i class="notification-action si si-check-circle-1 p-mr-1 " />
@@ -61,7 +61,7 @@
                 </h:panelGroup>
               </div>
             </div>
-            
+
             <div>
               <h:outputText value="#{notification.createdAt}" style="font-size: 0.75em;">
                 <f:convertDateTime type="both" dateStyle="medium" timeStyle="short" />

--- a/dev-workflow-ui/webContent/resources/css/workflow-ui.css
+++ b/dev-workflow-ui/webContent/resources/css/workflow-ui.css
@@ -272,6 +272,9 @@ body .custom-accordion.ui-accordion .ui-accordion-header:first-child {
 .notification-action-container {
   align-items: center;
 }
+.notification-mark-as-read {
+  margin-left: 5px;
+}
 body .notification-scroll>.ui-datascroller-content  {
   border: 0px;
   padding: 2px;

--- a/dev-workflow-ui/webContent/resources/css/workflow-ui.css
+++ b/dev-workflow-ui/webContent/resources/css/workflow-ui.css
@@ -257,7 +257,7 @@ body .custom-accordion.ui-accordion .ui-accordion-header:first-child {
   border-radius:10px;
   background-color:var(--ivy-primary-color);
 }
-.notification-button.si {
+.notification-action.si {
   font-size: 1.2em;
 }
 .notification-container {
@@ -265,6 +265,12 @@ body .custom-accordion.ui-accordion .ui-accordion-header:first-child {
   padding-left:0px;
   padding-right:0px;
   margin-bottom:0.15em;
+}
+.notification-message {
+  color: var(--primary-text-color);
+}
+.notification-action-container {
+  align-items: center;
 }
 body .notification-scroll>.ui-datascroller-content  {
   border: 0px;


### PR DESCRIPTION
Before:
![image](https://github.com/axonivy/dev-workflow-ui/assets/141232142/6a261408-7cd0-4d71-9a37-c40fb570a516)


After:
![image](https://github.com/axonivy/dev-workflow-ui/assets/141232142/4b685ce2-8136-439e-8881-fed872c204cf)

I noticed some issues we probably should discuss. Probably easier to explain in a meeting, but here are some notes:

Even though `WebNotification` contains a `List<WebNotificationAction>`, I assume there is exactly one `WebNotificationType.INFO` and zero or one `WebNotificationType.RUN` for now. If this changes, the implementation of the UI has to change as well. If this stays, maybe we should just provide two individual attributes for these?

In case of a list (at least for `WebNotificationType.RUN`) we could iterate over all of them and display a link/icon for each. However, I do not know what they do. All would have the same icon and the same tool tip. Another attribute like a description would be necessary for customization. To also make this language specific seems cumbersome. Maybe an `Enum` again with which the right CMS entry is acquired?

For new task notifications, I cannot easily determine whether a task has been completed or not. This means, I cannot hide the run link/icon if that is the case. Maybe we should add a method to `WebNotificationAction` that determines whether the action should be shown or not? Although, this will require information about the task to be present either in the `WebNotificationAction` or the `WebNotification` itself. 

This makes me think we should split `NotifcationAction` more precisely into something like:
```
> NotificationAction
  > InfoAction (one per Notification, in its own attribute)
  > RunnableAction (one or a list per Notification)
    > StartTaskAction
    > etc.
```

Another idea is to simply provide `WebNotification` with the `ITask` and/or `ICase`. I think this way we could completely remove the whole `NotificationAction` infrastructure again, as we then have access to all the links through that. At least for the current requirements this would be sufficient, or am I missing something?