### PR TITLE
XIVY-13553 Streamline jsf namespaces from sun.com/jsf to jcp.org/jsf

### DIFF
--- a/dev-workflow-ui-test-data/webContent/layouts/includes/progress-loader.xhtml
+++ b/dev-workflow-ui-test-data/webContent/layouts/includes/progress-loader.xhtml
@@ -1,5 +1,5 @@
-<ui:composition xmlns="http://www.w3.org/1999/xhtml" xmlns:f="http://java.sun.com/jsf/core"
-  xmlns:h="http://java.sun.com/jsf/html" xmlns:ui="http://java.sun.com/jsf/facelets" xmlns:p="http://primefaces.org/ui"
+<ui:composition xmlns="http://www.w3.org/1999/xhtml" xmlns:f="http://xmlns.jcp.org/jsf/core"
+  xmlns:h="http://xmlns.jcp.org/jsf/html" xmlns:ui="http://xmlns.jcp.org/jsf/facelets" xmlns:p="http://primefaces.org/ui"
   xmlns:pa="http://primefaces.org/serenity">
 
   <p:ajaxStatus id="ajaxLoadingStatus">

--- a/dev-workflow-ui/webContent/includes/components/allTasksTable.xhtml
+++ b/dev-workflow-ui/webContent/includes/components/allTasksTable.xhtml
@@ -2,7 +2,7 @@
   xmlns:h="http://xmlns.jcp.org/jsf/html" xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
   xmlns:c="http://xmlns.jcp.org/jsp/jstl/core" xmlns:ic="http://ivyteam.ch/jsf/component"
   xmlns:p="http://primefaces.org/ui" xmlns:pe="http://primefaces.org/ui/extensions"
-  xmlns:jc="http://java.sun.com/jsf/composite/components">
+  xmlns:jc="http://xmlns.jcp.org/jsf/composite/components">
 
   <p:dataTable id="tasks" var="task" value="#{tasksIvyDevWfBean.tasksDataModel}" widgetVar="tasksTable" styleClass="ui-fluid"
     emptyMessage="No Tasks found with given criteria" lazy="true" paginatorPosition="bottom" rows="10" paginator="true" paginatorAlwaysVisible="false"

--- a/dev-workflow-ui/webContent/includes/components/caseDetails/caseList.xhtml
+++ b/dev-workflow-ui/webContent/includes/components/caseDetails/caseList.xhtml
@@ -2,7 +2,7 @@
   xmlns:h="http://xmlns.jcp.org/jsf/html" xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
   xmlns:c="http://xmlns.jcp.org/jsp/jstl/core" xmlns:ic="http://ivyteam.ch/jsf/component"
   xmlns:p="http://primefaces.org/ui" xmlns:pe="http://primefaces.org/ui/extensions"
-  xmlns:jc="http://java.sun.com/jsf/composite/components">
+  xmlns:jc="http://xmlns.jcp.org/jsf/composite/components">
 
   <h:panelGroup id="caseHierarchy">
     <h:panelGroup layout="block" class="#{casesDetailsIvyDevWfBean.isCurrentHierarchyCase(casesDetailsIvyDevWfBean.selectedCase.getBusinessCase())}">

--- a/dev-workflow-ui/webContent/includes/components/caseDetails/description.xhtml
+++ b/dev-workflow-ui/webContent/includes/components/caseDetails/description.xhtml
@@ -2,7 +2,7 @@
   xmlns:h="http://xmlns.jcp.org/jsf/html" xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
   xmlns:c="http://xmlns.jcp.org/jsp/jstl/core" xmlns:ic="http://ivyteam.ch/jsf/component"
   xmlns:p="http://primefaces.org/ui" xmlns:pe="http://primefaces.org/ui/extensions"
-  xmlns:jc="http://java.sun.com/jsf/composite/components">
+  xmlns:jc="http://xmlns.jcp.org/jsf/composite/components">
 
   <p:panelGrid id="caseDetails" columns="4" layout="flex" contentStyleClass="p-ai-center"
     columnClasses="details-description-label p-col-6 p-md-2, p-col-6 p-md-4,

--- a/dev-workflow-ui/webContent/includes/components/caseDetails/taskList.xhtml
+++ b/dev-workflow-ui/webContent/includes/components/caseDetails/taskList.xhtml
@@ -2,7 +2,7 @@
   xmlns:h="http://xmlns.jcp.org/jsf/html" xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
   xmlns:c="http://xmlns.jcp.org/jsp/jstl/core" xmlns:ic="http://ivyteam.ch/jsf/component"
   xmlns:p="http://primefaces.org/ui" xmlns:pe="http://primefaces.org/ui/extensions"
-  xmlns:jc="http://java.sun.com/jsf/composite/components">
+  xmlns:jc="http://xmlns.jcp.org/jsf/composite/components">
 
   <p:dataTable id="tasks" var="task" value="#{casesDetailsIvyDevWfBean.tasks}" rowKey="#{task.name}"
     widgetVar="tasksTable" emptyMessage="No Tasks found with given criteria" lazy="true"

--- a/dev-workflow-ui/webContent/includes/components/casesTable.xhtml
+++ b/dev-workflow-ui/webContent/includes/components/casesTable.xhtml
@@ -2,7 +2,7 @@
   xmlns:h="http://xmlns.jcp.org/jsf/html" xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
   xmlns:c="http://xmlns.jcp.org/jsp/jstl/core" xmlns:ic="http://ivyteam.ch/jsf/component"
   xmlns:p="http://primefaces.org/ui" xmlns:pe="http://primefaces.org/ui/extensions"
-  xmlns:jc="http://java.sun.com/jsf/composite/components">
+  xmlns:jc="http://xmlns.jcp.org/jsf/composite/components">
 
   <p:dataTable id="cases" var="case" value="#{casesIvyDevWfBean.casesDataModel}" widgetVar="casesTable" styleClass="ui-fluid"
     emptyMessage="No Cases found with given criteria" paginatorPosition="bottom" rows="10" lazy="true" paginator="true"

--- a/dev-workflow-ui/webContent/includes/components/personalTasksTable.xhtml
+++ b/dev-workflow-ui/webContent/includes/components/personalTasksTable.xhtml
@@ -2,7 +2,7 @@
   xmlns:h="http://xmlns.jcp.org/jsf/html" xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
   xmlns:c="http://xmlns.jcp.org/jsp/jstl/core" xmlns:ic="http://ivyteam.ch/jsf/component"
   xmlns:p="http://primefaces.org/ui" xmlns:pe="http://primefaces.org/ui/extensions"
-  xmlns:jc="http://java.sun.com/jsf/composite/components">
+  xmlns:jc="http://xmlns.jcp.org/jsf/composite/components">
 
   <p:dataTable id="tasks" var="task" value="#{personalTasksIvyDevWfBean.tasksDataModel}" widgetVar="tasksTable" styleClass="ui-fluid"
     emptyMessage="No Tasks found with given criteria" lazy="true" paginatorPosition="bottom" rows="10" paginator="true" paginatorAlwaysVisible="false"

--- a/dev-workflow-ui/webContent/includes/components/signals/boundarySignals.xhtml
+++ b/dev-workflow-ui/webContent/includes/components/signals/boundarySignals.xhtml
@@ -2,7 +2,7 @@
   xmlns:h="http://xmlns.jcp.org/jsf/html" xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
   xmlns:c="http://xmlns.jcp.org/jsp/jstl/core" xmlns:ic="http://ivyteam.ch/jsf/component"
   xmlns:p="http://primefaces.org/ui" xmlns:pe="http://primefaces.org/ui/extensions"
-  xmlns:jc="http://java.sun.com/jsf/composite/components">
+  xmlns:jc="http://xmlns.jcp.org/jsf/composite/components">
 
   <p:dataTable id="boundarySignalsTable" var="receiver" value="#{signalsIvyDevWfBean.boundarySignalModel}" lazy="true"
     rows="5" paginator="true" paginatorPosition="bottom" paginatorAlwaysVisible="false">

--- a/dev-workflow-ui/webContent/includes/components/signals/firedSignals.xhtml
+++ b/dev-workflow-ui/webContent/includes/components/signals/firedSignals.xhtml
@@ -2,7 +2,7 @@
   xmlns:h="http://xmlns.jcp.org/jsf/html" xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
   xmlns:c="http://xmlns.jcp.org/jsp/jstl/core" xmlns:ic="http://ivyteam.ch/jsf/component"
   xmlns:p="http://primefaces.org/ui" xmlns:pe="http://primefaces.org/ui/extensions"
-  xmlns:jc="http://java.sun.com/jsf/composite/components">
+  xmlns:jc="http://xmlns.jcp.org/jsf/composite/components">
 
   <p:dataTable id="firedSignalsTable" var="signal" value="#{signalsIvyDevWfBean.signalsModel}"
     rows="10" paginator="true" paginatorAlwaysVisible="false" lazy="true" paginatorPosition="bottom">

--- a/dev-workflow-ui/webContent/includes/components/startsPanel.xhtml
+++ b/dev-workflow-ui/webContent/includes/components/startsPanel.xhtml
@@ -2,7 +2,7 @@
   xmlns:h="http://xmlns.jcp.org/jsf/html" xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
   xmlns:c="http://xmlns.jcp.org/jsp/jstl/core" xmlns:ic="http://ivyteam.ch/jsf/component"
   xmlns:p="http://primefaces.org/ui" xmlns:pe="http://primefaces.org/ui/extensions"
-  xmlns:jc="http://java.sun.com/jsf/composite/components">
+  xmlns:jc="http://xmlns.jcp.org/jsf/composite/components">
 
 <p:panel styleClass="main-starts-container ui-fluid">
   <f:facet name="header">

--- a/dev-workflow-ui/webContent/includes/components/taskDetails/description.xhtml
+++ b/dev-workflow-ui/webContent/includes/components/taskDetails/description.xhtml
@@ -2,7 +2,7 @@
   xmlns:h="http://xmlns.jcp.org/jsf/html" xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
   xmlns:c="http://xmlns.jcp.org/jsp/jstl/core" xmlns:ic="http://ivyteam.ch/jsf/component"
   xmlns:p="http://primefaces.org/ui" xmlns:pe="http://primefaces.org/ui/extensions"
-  xmlns:jc="http://java.sun.com/jsf/composite/components">
+  xmlns:jc="http://xmlns.jcp.org/jsf/composite/components">
 
   <p:panelGrid id="taskDetail" columns="4" layout="flex" contentStyleClass="p-ai-center"
     columnClasses="details-description-label p-d-flex p-ai-center p-col-6 p-md-2, p-d-flex p-ai-center p-col-6 p-md-4,

--- a/dev-workflow-ui/webContent/includes/components/taskDetails/descriptionCardHeaderActions.xhtml
+++ b/dev-workflow-ui/webContent/includes/components/taskDetails/descriptionCardHeaderActions.xhtml
@@ -2,7 +2,7 @@
   xmlns:h="http://xmlns.jcp.org/jsf/html" xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
   xmlns:c="http://xmlns.jcp.org/jsp/jstl/core" xmlns:ic="http://ivyteam.ch/jsf/component"
   xmlns:p="http://primefaces.org/ui" xmlns:pe="http://primefaces.org/ui/extensions"
-  xmlns:jc="http://java.sun.com/jsf/composite/components">
+  xmlns:jc="http://xmlns.jcp.org/jsf/composite/components">
 
   <div class="detail-action-container">
     <h:form id="actionMenuForm">

--- a/dev-workflow-ui/webContent/includes/template/progress-loader.xhtml
+++ b/dev-workflow-ui/webContent/includes/template/progress-loader.xhtml
@@ -1,5 +1,5 @@
-<ui:composition xmlns="http://www.w3.org/1999/xhtml" xmlns:f="http://java.sun.com/jsf/core"
-  xmlns:h="http://java.sun.com/jsf/html" xmlns:ui="http://java.sun.com/jsf/facelets" xmlns:p="http://primefaces.org/ui"
+<ui:composition xmlns="http://www.w3.org/1999/xhtml" xmlns:f="http://xmlns.jcp.org/jsf/core"
+  xmlns:h="http://xmlns.jcp.org/jsf/html" xmlns:ui="http://xmlns.jcp.org/jsf/facelets" xmlns:p="http://primefaces.org/ui"
   xmlns:pa="http://primefaces.org/serenity">
 
   <p:ajaxStatus id="ajaxLoadingStatus" delay="250">

--- a/dev-workflow-ui/webContent/includes/template/sidebar.xhtml
+++ b/dev-workflow-ui/webContent/includes/template/sidebar.xhtml
@@ -1,5 +1,5 @@
-<ui:composition xmlns="http://www.w3.org/1999/xhtml" xmlns:f="http://java.sun.com/jsf/core"
-  xmlns:h="http://java.sun.com/jsf/html" xmlns:ui="http://java.sun.com/jsf/facelets" xmlns:p="http://primefaces.org/ui"
+<ui:composition xmlns="http://www.w3.org/1999/xhtml" xmlns:f="http://xmlns.jcp.org/jsf/core"
+  xmlns:h="http://xmlns.jcp.org/jsf/html" xmlns:ui="http://xmlns.jcp.org/jsf/facelets" xmlns:p="http://primefaces.org/ui"
   xmlns:pm="http://primefaces.org/freya-ivy">
   <div class="menu-wrapper">
     <div class="sidebar-logo">

--- a/dev-workflow-ui/webContent/includes/template/template.xhtml
+++ b/dev-workflow-ui/webContent/includes/template/template.xhtml
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:h="http://java.sun.com/jsf/html" xmlns:f="http://java.sun.com/jsf/core"
-  xmlns:ui="http://java.sun.com/jsf/facelets" xmlns:p="http://primefaces.org/ui" lang="en">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:h="http://xmlns.jcp.org/jsf/html" xmlns:f="http://xmlns.jcp.org/jsf/core"
+  xmlns:ui="http://xmlns.jcp.org/jsf/facelets" xmlns:p="http://primefaces.org/ui" lang="en">
 <h:head>
   <f:attribute name="primefaces.THEME" value="freya-ivy-#{ivyFreyaTheme.mode}" />
   <f:facet name="first">

--- a/dev-workflow-ui/webContent/resources/components/workflowEventsTable.xhtml
+++ b/dev-workflow-ui/webContent/resources/components/workflowEventsTable.xhtml
@@ -2,7 +2,7 @@
   xmlns:h="http://xmlns.jcp.org/jsf/html" xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
   xmlns:cc="http://xmlns.jcp.org/jsf/composite" xmlns:ic="http://ivyteam.ch/jsf/component"
   xmlns:p="http://primefaces.org/ui" xmlns:pe="http://primefaces.org/ui/extensions"
-  xmlns:jc="http://java.sun.com/jsf/composite/components">
+  xmlns:jc="http://xmlns.jcp.org/jsf/composite/components">
 <cc:interface>
   <cc:attribute name="workflowEvents" />
 </cc:interface>

--- a/dev-workflow-ui/webContent/view/case.xhtml
+++ b/dev-workflow-ui/webContent/view/case.xhtml
@@ -2,7 +2,7 @@
   xmlns:h="http://xmlns.jcp.org/jsf/html" xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
   xmlns:ic="http://ivyteam.ch/jsf/component" xmlns:p="http://primefaces.org/ui"
   xmlns:pe="http://primefaces.org/ui/extensions" xmlns:c="http://xmlns.jcp.org/jsp/jstl/core"
-  xmlns:pm="http://primefaces.org/serenity-ivy" xmlns:jc="http://java.sun.com/jsf/composite/components"
+  xmlns:pm="http://primefaces.org/serenity-ivy" xmlns:jc="http://xmlns.jcp.org/jsf/composite/components"
   xmlns:jsf="http://xmlns.jcp.org/jsf">
 
 <h:body>

--- a/dev-workflow-ui/webContent/view/home.xhtml
+++ b/dev-workflow-ui/webContent/view/home.xhtml
@@ -1,7 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:f="http://xmlns.jcp.org/jsf/core"
   xmlns:h="http://xmlns.jcp.org/jsf/html" xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
   xmlns:ic="http://ivyteam.ch/jsf/component" xmlns:p="http://primefaces.org/ui"
-  xmlns:pe="http://primefaces.org/ui/extensions" xmlns:jc="http://java.sun.com/jsf/composite/components">
+  xmlns:pe="http://primefaces.org/ui/extensions" xmlns:jc="http://xmlns.jcp.org/jsf/composite/components">
 
 <h:body>
   <ui:composition template="../includes/template/template.xhtml">

--- a/dev-workflow-ui/webContent/view/intermediateEventDetails.xhtml
+++ b/dev-workflow-ui/webContent/view/intermediateEventDetails.xhtml
@@ -1,7 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:f="http://xmlns.jcp.org/jsf/core"
   xmlns:h="http://xmlns.jcp.org/jsf/html" xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
   xmlns:ic="http://ivyteam.ch/jsf/component" xmlns:p="http://primefaces.org/ui"
-  xmlns:pe="http://primefaces.org/ui/extensions" xmlns:jc="http://java.sun.com/jsf/composite/components">
+  xmlns:pe="http://primefaces.org/ui/extensions" xmlns:jc="http://xmlns.jcp.org/jsf/composite/components">
 
 <h:body>
   <f:metadata>

--- a/dev-workflow-ui/webContent/view/login.xhtml
+++ b/dev-workflow-ui/webContent/view/login.xhtml
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:h="http://java.sun.com/jsf/html" xmlns:f="http://java.sun.com/jsf/core"
-  xmlns:ui="http://java.sun.com/jsf/facelets" xmlns:p="http://primefaces.org/ui" xmlns:c="http://java.sun.com/jsp/jstl/core">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:h="http://xmlns.jcp.org/jsf/html" xmlns:f="http://xmlns.jcp.org/jsf/core"
+  xmlns:ui="http://xmlns.jcp.org/jsf/facelets" xmlns:p="http://primefaces.org/ui" xmlns:c="http://java.sun.com/jsp/jstl/core">
 
 <h:head>
   <f:attribute name="primefaces.THEME" value="freya-ivy-#{ivyFreyaTheme.mode}" />

--- a/dev-workflow-ui/webContent/view/starts.xhtml
+++ b/dev-workflow-ui/webContent/view/starts.xhtml
@@ -1,7 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:f="http://xmlns.jcp.org/jsf/core"
   xmlns:h="http://xmlns.jcp.org/jsf/html" xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
   xmlns:ic="http://ivyteam.ch/jsf/component" xmlns:p="http://primefaces.org/ui"
-  xmlns:pe="http://primefaces.org/ui/extensions" xmlns:jc="http://java.sun.com/jsf/composite/components">
+  xmlns:pe="http://primefaces.org/ui/extensions" xmlns:jc="http://xmlns.jcp.org/jsf/composite/components">
 
 <h:body>
   <ui:composition template="../includes/template/template.xhtml">

--- a/dev-workflow-ui/webContent/view/task.xhtml
+++ b/dev-workflow-ui/webContent/view/task.xhtml
@@ -2,7 +2,7 @@
   xmlns:h="http://xmlns.jcp.org/jsf/html" xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
   xmlns:ic="http://ivyteam.ch/jsf/component" xmlns:p="http://primefaces.org/ui"
   xmlns:pe="http://primefaces.org/ui/extensions" xmlns:c="http://xmlns.jcp.org/jsp/jstl/core"
-  xmlns:pm="http://primefaces.org/serenity-ivy" xmlns:jc="http://java.sun.com/jsf/composite/components">
+  xmlns:pm="http://primefaces.org/serenity-ivy" xmlns:jc="http://xmlns.jcp.org/jsf/composite/components">
 
 <h:body>
   <f:metadata>


### PR DESCRIPTION
Replace old JSF namespaces http://java.sun.com/jsf/* with new JSF 2.2 namepaces http://xmlns.jcp.org/jsf/*