### PR TITLE
Feature/XIVY-13553 make test more reliable

### DIFF
--- a/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestHomepageIT.java
+++ b/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestHomepageIT.java
@@ -1,6 +1,6 @@
 package ch.ivyteam.ivy.project.workflow.webtest;
 
-import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.customLogin;
+import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.login;
 import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.loginDeveloper;
 import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.logout;
 import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.openView;
@@ -24,7 +24,7 @@ public class WebTestHomepageIT {
 
   @Test
   public void homepageContainers() {
-    customLogin("DifferentLogin", "DifferentPassword");
+    login("DifferentLogin", "DifferentPassword");
 
     // start process to create test data
     openView("starts.xhtml");

--- a/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestLoginIT.java
+++ b/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestLoginIT.java
@@ -63,15 +63,14 @@ public class WebTestLoginIT {
 
   @Test
   void customLogin() {
-    WorkflowUiUtil.customLogin("DeveloperTest", "DeveloperTest");
-    Selenide.webdriver().shouldNotHave(urlContaining("/login.xhtml"));
+    WorkflowUiUtil.login("DeveloperTest", "DeveloperTest");
   }
 
   @Test
   void customLoginFailMessage() {
     openView("login.xhtml");
     $("#loginForm\\:loginMessage").shouldNotBe(visible);
-    WorkflowUiUtil.customLogin("sadgs", "sdgasgd");
+    WorkflowUiUtil.tryLogin("sadgs", "sdgasgd");
     $("#loginForm\\:loginMessage").shouldBe(visible);
   }
 
@@ -121,8 +120,7 @@ public class WebTestLoginIT {
   void loginTableRedirect() {
     loginFromTable("DifferentLogin");
     assertCurrentUrlContains("login.xhtml?originalUrl=loginTable.xhtml");
-    WorkflowUiUtil.customLogin("DifferentLogin", "DifferentPassword");
-    $("#sessionUserName").shouldHave(text("DifferentLogin"));
+    WorkflowUiUtil.login("DifferentLogin", "DifferentPassword");
   }
 
   @Test

--- a/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/util/WorkflowUiUtil.java
+++ b/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/util/WorkflowUiUtil.java
@@ -3,6 +3,7 @@ package ch.ivyteam.ivy.project.workflow.webtest.util;
 import static com.axonivy.ivy.webtest.engine.EngineUrl.createCaseMapUrl;
 import static com.axonivy.ivy.webtest.engine.EngineUrl.createProcessUrl;
 import static com.codeborne.selenide.Condition.exist;
+import static com.codeborne.selenide.Condition.interactable;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selectors.byText;
@@ -89,12 +90,18 @@ public class WorkflowUiUtil {
   }
 
   public static void loginDeveloper() {
-    customLogin("DeveloperTest", "DeveloperTest");
+    login("DeveloperTest", "DeveloperTest");
   }
 
-  public static void customLogin(String username, String password) {
+  public static void login(String username, String password) {
+    tryLogin(username, password);
+    webdriver().shouldNotHave(urlContaining("login.xhtml"));
+    $("#sessionUserName").shouldHave(text(username));
+  }
+
+  public static void tryLogin(String username, String password) {
     open(viewUrl("login.xhtml"));
-    $("#loginForm\\:userName").clear();
+    $("#loginForm\\:userName").shouldBe(interactable).clear();
     $("#loginForm\\:userName").sendKeys(username);
     $("#loginForm\\:password").clear();
     $("#loginForm\\:password").sendKeys(password);

--- a/dev-workflow-ui/src/ch/ivyteam/workflowui/FrameIvyDevWfBean.java
+++ b/dev-workflow-ui/src/ch/ivyteam/workflowui/FrameIvyDevWfBean.java
@@ -42,11 +42,12 @@ public class FrameIvyDevWfBean {
 
   private String checkTaskUrl() {
     var url = UrlUtil.getUrlParameter("taskUrl");
-    if (StringUtils.startsWith(url, "/")) {
+    if (url == null || url.startsWith("/")) {
       return url;
     } else {
+      String info = "taskUrl=" + url + "[url="+UrlUtil.getHttpServletRequest().getRequestURI()+", query="+UrlUtil.getHttpServletRequest().getQueryString()+"]";
       throw BpmError.create("frame:unsupported:url")
-              .withMessage("Only relative urls are supported (security reasons): " + url).build();
+              .withMessage("Only relative urls are supported (security reasons): " + info).build();
     }
   }
 


### PR DESCRIPTION
If login fails, fail early

There were a lot of 'Only relative URLs are supported ...' error messages in the log. It seems that taskUrl can be null in which case this happens. Not sure how this can happen the test never calls 'frame.xhml'.