### PR TITLE
fix: code-of-conduct by not applying code whitespace rules to markdown

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@
 # top-most EditorConfig file
 root = true
 
-[*.{java,md,css,xhtml,js}]
+[*.{java,css,xhtml,js}]
 end_of_line = lf
 indent_style = space
 indent_size = 2


### PR DESCRIPTION
- a double-whitespace at the end of a line in markdown is the valid way to express a line-break ... therefore we should not prevent this with our editor config