### PR TITLE
Add ajax exception handler

### DIFF
--- a/dev-workflow-ui/webContent/includes/template/exception-details.xhtml
+++ b/dev-workflow-ui/webContent/includes/template/exception-details.xhtml
@@ -1,0 +1,128 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+  xmlns:f="http://xmlns.jcp.org/jsf/core"
+  xmlns:h="http://xmlns.jcp.org/jsf/html"
+  xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+  xmlns:p="http://primefaces.org/ui"
+  xmlns:pe="http://primefaces.org/ui/extensions">
+
+<ui:fragment rendered="#{!errorPage.showDetails}">
+  <h:outputText value="An unexpected error has occured:" />
+</ui:fragment>
+
+<h1 class="bg-warning">
+  <h:outputText value="#{errorPage.message}" />
+</h1>
+
+<ui:fragment rendered="#{errorPage.isIvyException()}">
+  <h4 class="list-group-item-heading" style="margin-top: 20px">Error
+    id</h4>
+  <p>#{errorPage.exceptionId}</p>
+</ui:fragment>
+
+<ui:fragment rendered="#{errorPage.showDetails}">
+  <h3 class="page-header">
+    <h:outputText value="#{errorPage.error.errorCode}" />
+    <span style="font-size: 0.8em"> <h:outputText
+        rendered="#{errorPage.error.message!=errorPage.error.errorCode}"
+        value=" #{errorPage.error.message}" />
+    </span>
+  </h3>
+  <ui:fragment rendered="#{!errorPage.error.attributeNames.isEmpty()}">
+    <h4 class="list-group-item-heading">Attributes</h4>
+    <div class="table-responsive">
+      <table class="table table-bordered table-striped"
+        style="font-size: 1.0em">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <ui:repeat value="#{errorPage.error.attributeNames}"
+            var="attributeName">
+            <tr>
+              <td><h:outputText value="#{attributeName}" /></td>
+              <td style="width: 100%"><h:outputText
+                  value="#{errorPage.error.getAttribute(attributeName)}" />
+              </td>
+            </tr>
+          </ui:repeat>
+        </tbody>
+      </table>
+    </div>
+  </ui:fragment>
+  <h4 class="list-group-item-heading">Thrown by</h4>
+  <p style="margin-bottom: 0;">
+    Process:
+    <h:outputText value="#{errorPage.path}" />
+    <br /> Element:
+    <h:outputText value="#{errorPage.error.processElement}" />
+  </p>
+  <br />
+
+  <ui:fragment rendered="#{!errorPage.error.processCallStack.isEmpty()}">
+    <h4 class="list-group-item-heading">Process call stack</h4>
+    <!-- Don't move me: I'm a PRE!!! -->
+    <pre>
+      <code>
+        <ui:repeat value="#{errorPage.error.processCallStack}"
+          var="caller">#{caller.callerElement}</ui:repeat>
+      </code>
+    </pre>
+    <br />
+  </ui:fragment>
+  <ui:fragment rendered="#{!errorPage.causedBy.isEmpty()}">
+    <h4 class="list-group-item-heading">Technical cause</h4>
+    <ui:repeat value="#{errorPage.causedBy}" var="causedBy">
+      <pre>
+        <code>#{causedBy.class.simpleName}: #{causedBy.message.trim()}</code>
+      </pre>
+    </ui:repeat>
+    <br />
+  </ui:fragment>
+
+  <h4 class="list-group-item-heading">Request Uri</h4>
+  <p>#{errorPage.getRequestUri()}</p>
+  <br />
+  <h4 class="list-group-item-heading">Servlet</h4>
+  <p>#{errorPage.getServletName()}</p>
+  <br />
+
+  <h4 class="list-group-item-heading">Application</h4>
+  <p>#{errorPage.applicationName}</p>
+  <br />
+
+  <ui:fragment rendered="#{!errorPage.threadLocalValues.isEmpty()}">
+    <h4 class="list-group-item-heading">Thread local values</h4>
+    <div class="table-responsive">
+      <table class="table table-bordered table-striped"
+        style="font-size: 0.9em">
+        <thead>
+          <tr>
+            <th>Key</th>
+            <th>Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <ui:repeat value="#{errorPage.threadLocalValues}"
+            var="threadLocal">
+            <tr>
+              <td><h:outputText value="#{threadLocal.key}" /></td>
+              <td style="width: 100%"><h:outputText
+                  value="#{threadLocal.value}" /></td>
+            </tr>
+          </ui:repeat>
+        </tbody>
+      </table>
+    </div>
+  </ui:fragment>
+  <br />
+
+  <h4 class="list-group-item-heading">Stack-Trace</h4>
+  <pre>
+    <code>#{errorPage.getStackTrace()}</code>
+  </pre>
+</ui:fragment>
+
+</html>

--- a/dev-workflow-ui/webContent/includes/template/exception.xhtml
+++ b/dev-workflow-ui/webContent/includes/template/exception.xhtml
@@ -1,0 +1,43 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+  xmlns:f="http://xmlns.jcp.org/jsf/core"
+  xmlns:h="http://xmlns.jcp.org/jsf/html"
+  xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+  xmlns:ic="http://ivyteam.ch/jsf/component"
+  xmlns:p="http://primefaces.org/ui"
+  xmlns:pe="http://primefaces.org/ui/extensions">
+
+<body>
+  <ui:composition>
+    <!-- Exception Handler for ViewExpiredExceptions -->
+    <p:ajaxExceptionHandler
+      type="javax.faces.application.ViewExpiredException"
+      update="viewExpiredExceptionDialog"
+      onexception="PF('viewExpiredExceptionDialog').show();" />
+
+    <!-- Error Dialog shown if a view or session has expired -->
+    <p:dialog id="viewExpiredExceptionDialog"
+      header="View or Session Expired"
+      widgetVar="viewExpiredExceptionDialog" height="150px" modal="true">
+      <h1>
+        <h:outputText value="The view or session has expired." />
+      </h1>
+      <br />
+      <p:button href="login.xhtml" value="Login" icon="si si-login-3" />
+    </p:dialog>
+
+    <!--  Exception Handler for any other Exception -->
+    <p:ajaxExceptionHandler update="ajaxExceptionDialog"
+      onexception="PF('ajaxExceptionDialog').show();" />
+
+    <!-- Error Dialog to show Exceptions -->
+    <p:dialog id="ajaxExceptionDialog" header="Error"
+      widgetVar="ajaxExceptionDialog" modal="true" closeOnEscape="true"
+      height="400px"
+      style="max-width: calc(100% - 300px); min-width: 300px;">
+      <ui:include src="exception-details.xhtml" />
+    </p:dialog>
+
+  </ui:composition>
+</body>
+
+</html>

--- a/dev-workflow-ui/webContent/includes/template/template.xhtml
+++ b/dev-workflow-ui/webContent/includes/template/template.xhtml
@@ -107,6 +107,7 @@
   </div>
 
   <ui:include src="progress-loader.xhtml" />
+  <ui:include src="exception.xhtml" />
 
   <h:outputStylesheet name="css/layout-ivy-#{ivyFreyaTheme.mode}.css" library="freya-layout" />
   <h:outputStylesheet name="primeflex-3.min.css" library="primeflex" />


### PR DESCRIPTION
Wondering that we don't have an ajax exception handler here? But maybe there is a specific reason? Copied the one from engine cockpit...

```
Could not handle exception!
java.lang.IllegalArgumentException: No default error page (Status 500 or java.lang.Throwable) and no error page for type "class javax.faces.application.ViewExpiredException" defined!
	at org.primefaces.application.exceptionhandler.PrimeExceptionHandler.evaluateErrorPage(PrimeExceptionHandler.java:441)
	at org.primefaces.application.exceptionhandler.PrimeExceptionHandler.handleRedirect(PrimeExceptionHandler.java:377)
	at org.primefaces.application.exceptionhandler.PrimeExceptionHandler.handleAjaxException(PrimeExceptionHandler.java:224)
	at org.primefaces.application.exceptionhandler.PrimeExceptionHandler.handle(PrimeExceptionHandler.java:119)
	at ch.ivyteam.ivy.jsf.primefaces.exception.IvyPrimeExceptionHandler.handle(IvyPrimeExceptionHandler.java:30)
	at javax.faces.context.ExceptionHandlerWrapper.handle(ExceptionHandlerWrapper.java:61)
	at ch.ivyteam.ivy.dialog.execution.jsf.error.RuntimeLogExceptionHandler.handle(RuntimeLogExceptionHandler.java:51)
	at javax.faces.context.ExceptionHandlerWrapper.handle(ExceptionHandlerWrapper.java:61)
	at ch.ivyteam.ivy.dialog.execution.jsf.error.RuntimeLogExceptionHandler.handle(RuntimeLogExceptionHandler.java:51)
	at org.apache.myfaces.lifecycle.LifecycleImpl.executePhase(LifecycleImpl.java:217)
	at org.apache.myfaces.lifecycle.LifecycleImpl.execute(LifecycleImpl.java:143)
	at javax.faces.webapp.FacesServlet.service(FacesServlet.java:198)
	at ch.ivyteam.ivy.webserver.restricted.jsf.IvyFacesServlet.service(IvyFacesServlet.java:35)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:210)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:154)
	at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:51)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:179)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:154)
	at org.apache.catalina.filters.HttpHeaderSecurityFilter.doFilter(HttpHeaderSecurityFilter.java:129)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:179)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:154)
	at ch.ivyteam.ivy.webserver.internal.filter.FilterChain.next(FilterChain.java:29)
	at ch.ivyteam.ivy.webserver.restricted.jsf.IvyFacesStaticViewFilter.lambda$0(IvyFacesStaticViewFilter.java:20)
	at ch.ivyteam.util.callable.IExecutionContext.lambda$0(IExecutionContext.java:28)
	at ch.ivyteam.util.callable.AbstractExecutionContext.callInContext(AbstractExecutionContext.java:10)
	at ch.ivyteam.util.callable.IExecutionContext.executeInContext(IExecutionContext.java:27)
	at ch.ivyteam.ivy.webserver.restricted.jsf.IvyFacesStaticViewFilter.doFilter(IvyFacesStaticViewFilter.java:20)
	at ch.ivyteam.ivy.webserver.internal.filter.AbstractFilter.doFilter(AbstractFilter.java:36)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:179)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:154)
	at ch.ivyteam.ivy.webserver.internal.filter.FilterChain.next(FilterChain.java:29)
	at ch.ivyteam.util.callable.IExecutionContext.lambda$0(IExecutionContext.java:28)
	at ch.ivyteam.util.callable.AbstractExecutionContext.callInContext(AbstractExecutionContext.java:10)
	at ch.ivyteam.util.callable.IExecutionContext.executeInContext(IExecutionContext.java:27)
	at ch.ivyteam.ivy.webserver.internal.filter.ProcessModelVersionFilter.doFilter(ProcessModelVersionFilter.java:33)
	at ch.ivyteam.ivy.webserver.internal.filter.AbstractFilter.doFilter(AbstractFilter.java:36)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:179)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:154)
	at ch.ivyteam.ivy.webserver.internal.filter.FilterChain.next(FilterChain.java:29)
	at ch.ivyteam.ivy.webserver.restricted.jsf.ConsumeNextPathFilter.doFilter(ConsumeNextPathFilter.java:12)
	at ch.ivyteam.ivy.webserver.internal.filter.AbstractFilter.doFilter(AbstractFilter.java:36)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:179)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:154)
	at ch.ivyteam.ivy.webserver.internal.filter.FilterChain.next(FilterChain.java:29)
	at ch.ivyteam.util.callable.IExecutionContext.lambda$0(IExecutionContext.java:28)
	at ch.ivyteam.util.callable.AbstractExecutionContext.callInContext(AbstractExecutionContext.java:10)
	at ch.ivyteam.util.callable.IExecutionContext.executeInContext(IExecutionContext.java:27)
	at ch.ivyteam.ivy.webserver.internal.filter.AbstractIvySessionFilter.executeInSessionContext(AbstractIvySessionFilter.java:33)
	at ch.ivyteam.ivy.webserver.internal.filter.AbstractIvySessionFilter.doFilter(AbstractIvySessionFilter.java:19)
	at ch.ivyteam.ivy.webserver.internal.filter.AbstractFilter.doFilter(AbstractFilter.java:36)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:179)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:154)
	at org.apache.catalina.filters.SetCharacterEncodingFilter.doFilter(SetCharacterEncodingFilter.java:115)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:179)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:154)
	at ch.ivyteam.ivy.webserver.internal.filter.FilterChain.next(FilterChain.java:29)
	at ch.ivyteam.util.callable.IExecutionContext.lambda$0(IExecutionContext.java:28)
	at ch.ivyteam.util.callable.AbstractExecutionContext.callInContext(AbstractExecutionContext.java:10)
	at ch.ivyteam.util.callable.IExecutionContext.executeInContext(IExecutionContext.java:27)
	at ch.ivyteam.ivy.webserver.internal.filter.SecurityContextFilter.doFilter(SecurityContextFilter.java:31)
	at ch.ivyteam.ivy.webserver.internal.filter.AbstractFilter.doFilter(AbstractFilter.java:36)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:179)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:154)
	at ch.ivyteam.ivy.webserver.internal.filter.FilterChain.next(FilterChain.java:29)
	at ch.ivyteam.util.callable.IExecutionContext.lambda$0(IExecutionContext.java:28)
	at ch.ivyteam.util.callable.AbstractExecutionContext.callInContext(AbstractExecutionContext.java:10)
	at ch.ivyteam.util.callable.IExecutionContext.executeInContext(IExecutionContext.java:27)
	at ch.ivyteam.ivy.webserver.internal.filter.ApplicationFilter.doFilter(ApplicationFilter.java:42)
	at ch.ivyteam.ivy.webserver.internal.filter.AbstractFilter.doFilter(AbstractFilter.java:36)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:179)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:154)
	at ch.ivyteam.ivy.webserver.internal.filter.FilterChain.next(FilterChain.java:29)
	at ch.ivyteam.ivy.webserver.internal.exception.ExceptionFilter.doFilter(ExceptionFilter.java:38)
	at ch.ivyteam.ivy.webserver.internal.filter.AbstractFilter.doFilter(AbstractFilter.java:36)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:179)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:154)
	at ch.ivyteam.ivy.webserver.internal.filter.FilterChain.next(FilterChain.java:29)
	at ch.ivyteam.ivy.webserver.internal.startup.IvyEngineUnavailableFilter.doFilter(IvyEngineUnavailableFilter.java:27)
	at ch.ivyteam.ivy.webserver.internal.filter.AbstractFilter.doFilter(AbstractFilter.java:36)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:179)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:154)
	at ch.ivyteam.ivy.webserver.internal.filter.FilterChain.next(FilterChain.java:29)
	at ch.ivyteam.util.callable.IExecutionContext.lambda$0(IExecutionContext.java:28)
	at ch.ivyteam.util.callable.AbstractExecutionContext.callInContext(AbstractExecutionContext.java:10)
	at ch.ivyteam.util.callable.IExecutionContext.executeInContext(IExecutionContext.java:27)
	at ch.ivyteam.ivy.webserver.internal.filter.RemoteClientFilter.doFilter(RemoteClientFilter.java:16)
	at ch.ivyteam.ivy.webserver.internal.filter.AbstractFilter.doFilter(AbstractFilter.java:36)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:179)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:154)
	at ch.ivyteam.ivy.webserver.internal.filter.FilterChain.next(FilterChain.java:29)
	at ch.ivyteam.util.callable.IExecutionContext.lambda$0(IExecutionContext.java:28)
	at ch.ivyteam.util.callable.AbstractExecutionContext.callInContext(AbstractExecutionContext.java:10)
	at ch.ivyteam.util.callable.IExecutionContext.executeInContext(IExecutionContext.java:27)
	at ch.ivyteam.ivy.webserver.internal.filter.IvyCurrentHttpRequestFilter.doFilter(IvyCurrentHttpRequestFilter.java:11)
	at ch.ivyteam.ivy.webserver.internal.filter.AbstractFilter.doFilter(AbstractFilter.java:36)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:179)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:154)
	at ch.ivyteam.ivy.webserver.internal.filter.FilterChain.next(FilterChain.java:29)
	at ch.ivyteam.util.callable.IExecutionContext.lambda$0(IExecutionContext.java:28)
	at ch.ivyteam.util.callable.AbstractExecutionContext.callInContext(AbstractExecutionContext.java:10)
	at ch.ivyteam.util.callable.IExecutionContext.executeInContext(IExecutionContext.java:27)
	at ch.ivyteam.ivy.security.exec.Sudo.execute(Sudo.java:111)
	at ch.ivyteam.ivy.webserver.internal.filter.IvyExecuteAsSystemFilter.doFilter(IvyExecuteAsSystemFilter.java:9)
	at ch.ivyteam.ivy.webserver.internal.filter.AbstractFilter.doFilter(AbstractFilter.java:36)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:179)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:154)
	at ch.ivyteam.ivy.webserver.internal.filter.FilterChain.next(FilterChain.java:29)
	at ch.ivyteam.ivy.webserver.internal.trace.PerformanceLogFilter.doLog(PerformanceLogFilter.java:61)
	at ch.ivyteam.ivy.webserver.internal.trace.PerformanceLogFilter.doFilter(PerformanceLogFilter.java:47)
	at ch.ivyteam.ivy.webserver.internal.filter.AbstractFilter.doFilter(AbstractFilter.java:36)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:179)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:154)
	at org.apache.catalina.filters.RemoteIpFilter.doFilter(RemoteIpFilter.java:927)
	at org.apache.catalina.filters.RemoteIpFilter.doFilter(RemoteIpFilter.java:983)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:179)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:154)
	at com.google.inject.servlet.FilterChainInvocation.doFilter(FilterChainInvocation.java:89)
	at com.google.inject.servlet.ManagedFilterPipeline.dispatch(ManagedFilterPipeline.java:121)
	at com.google.inject.servlet.GuiceFilter.doFilter(GuiceFilter.java:133)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:179)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:154)
	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:168)
	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:90)
	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:481)
	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:130)
	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:93)
	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:74)
	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:346)
	at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:390)
	at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:63)
	at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:928)
	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1786)
	at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:52)
	at org.apache.tomcat.util.threads.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1191)
	at org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:659)
	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:63)
```