### PR TITLE
Fix version of maven plugins (best practices and warning with Maven 4

### DIFF
--- a/maven/config/pom.xml
+++ b/maven/config/pom.xml
@@ -84,6 +84,16 @@
             <skip>true</skip>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>3.1.2</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.3.1</version>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>


### PR DESCRIPTION
Maven 3.9.8 already tries to use maven 4 plugins. Because they are not compatible it will give a warning and is using an older one.