### PR TITLE
Streamline cockpit icon to use the same family as surrounding icons

### DIFF
--- a/dev-workflow-ui/webContent/includes/template/template.xhtml
+++ b/dev-workflow-ui/webContent/includes/template/template.xhtml
@@ -55,7 +55,7 @@
 
             <li class="topbar-item">
               <a href="#{sidebarIvyDevWfBean.cockpitPath}" title="Engine Cockpit">
-                <i class="topbar-icon si si-cog animated swing"></i>
+                <i class="topbar-icon pi pi-cog"></i>
               </a>
             </li>
 


### PR DESCRIPTION
I noticed that the cog icon looked kind of out of place. I checked and it is a streamline icon `si si-...` while the other surrounding icons are primeicons `pi pi-...`


![2024-07-24_11-45_1](https://github.com/user-attachments/assets/dcebf034-62f0-44aa-8f85-02eac44a364a)
![2024-07-24_11-45](https://github.com/user-attachments/assets/ae0a7d36-be30-477f-acb6-42671a801861)

Also i didnt notice `animated` and `swing` classes affect anything.