### PR TITLE
XIVY-14658 Streamline datetime component and occurences

### DIFF
--- a/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestTasksIT.java
+++ b/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestTasksIT.java
@@ -186,7 +186,7 @@ class WebTestTasksIT {
     $(By.className("detail-btn")).shouldBe(visible).click();
     $(By.id("taskName")).shouldBe(exactText("Created delayed task"));
     $(By.id("taskState")).shouldBe(exactText("DELAYED (DELAYED)"));
-    $(By.id("delayDate")).shouldNotBe(exactText("N/A"));
+    $(By.id("delayDate:datetime")).shouldNotBe(exactText(""));
     $(By.id("actionMenuForm:taskStartBtn")).shouldHave(cssClass("ui-state-disabled"));
   }
 
@@ -229,13 +229,13 @@ class WebTestTasksIT {
     $(By.className("detail-btn")).shouldBe(visible).click();
 
     $(By.id("taskState")).shouldBe(exactText("DELAYED (DELAYED)"));
-    $(By.id("delayDate")).shouldNotBe(exactText("N/A"));
+    $(By.id("delayDate:datetime")).shouldNotBe(exactText(""));
 
     $(By.id("actionMenuForm:taskActionsBtn")).click();
     $(By.id("actionMenuForm:taskClearDelayBtn")).should(visible).click();
 
     $(By.id("taskState")).shouldBe(exactText("OPEN (SUSPENDED)"));
-    $(By.id("delayDate")).shouldBe(exactText("N/A"));
+    $(By.id("delayDate:datetime")).shouldBe(exactText(""));
   }
 
   @Test

--- a/dev-workflow-ui/src/ch/ivyteam/workflowui/DateTimeIvyDevWfBean.java
+++ b/dev-workflow-ui/src/ch/ivyteam/workflowui/DateTimeIvyDevWfBean.java
@@ -18,12 +18,4 @@ public class DateTimeIvyDevWfBean {
   public String getDefault(Date date) {
     return DateUtil.getDefault(date);
   }
-
-  public String getDetailed(Date date) {
-    return date == null ? "N/A" : DateUtil.getDetailed(date);
-  }
-
-  public String getDateTimeNoYear(Date date) {
-    return date == null ? "N/A" : DateUtil.getDateTimeNoYear(date);
-  }
 }

--- a/dev-workflow-ui/src/ch/ivyteam/workflowui/util/DateUtil.java
+++ b/dev-workflow-ui/src/ch/ivyteam/workflowui/util/DateUtil.java
@@ -11,7 +11,6 @@ import org.ocpsoft.prettytime.PrettyTime;
 public class DateUtil {
   private static final PrettyTime pretty = new PrettyTime();
   private static final DateTimeFormatter defaultFormatter = DateTimeFormatter.ofPattern("dd.MM.yyyy, HH:mm");
-  private static final DateTimeFormatter detailedFormatter = DateTimeFormatter.ofPattern("dd.MM.yyyy, HH:mm:ss");
 
   public static String getPrettyTime(Date date) {
     if (date == null) {
@@ -28,14 +27,6 @@ public class DateUtil {
 
   public static String getDefault(Date date) {
     return formatDate(date, defaultFormatter);
-  }
-
-  public static String getDetailed(Date date) {
-    return formatDate(date, detailedFormatter);
-  }
-
-  public static String getDateTimeNoYear(Date date) {
-    return formatDate(date, DateTimeFormatter.ofPattern("dd MMM, HH:mm"));
   }
 
   private static String formatDate(Date date, DateTimeFormatter format)

--- a/dev-workflow-ui/webContent/includes/components/caseDetails/description.xhtml
+++ b/dev-workflow-ui/webContent/includes/components/caseDetails/description.xhtml
@@ -32,18 +32,14 @@
     <h:outputText value="#{case.category.name}" id="category" />
 
     <h:outputText value="Created" />
-    <h:outputText value="#{dateTimeIvyDevWfBean.getDefault(case.getStartTimestamp())}"
-      id="createdDate" />
+    <jc:datetime datetime="#{case.startTimestamp}" id="createdDate" />
 
     <h:outputText value="Completed on" />
-    <h:outputText value="#{dateTimeIvyDevWfBean.getDetailed(case.getEndTimestamp())}"
-      id="expiryDate" />
+    <jc:datetime datetime="#{case.endTimestamp}" id="expiryDate" />
 
     <h:outputText value="Description" />
     <h:outputText value="#{casesDetailsIvyDevWfBean.description}" id="caseDescription" />
   </p:panelGrid>
   <p:tooltip for="caseId" value="ID: #{case.getId()}" />
-  <p:tooltip for="createdDate" value="#{dateTimeIvyDevWfBean.getPrettyTime(case.getStartTimestamp())}"
-    position="top" />
 
 </ui:composition>

--- a/dev-workflow-ui/webContent/includes/components/casesTable.xhtml
+++ b/dev-workflow-ui/webContent/includes/components/casesTable.xhtml
@@ -38,11 +38,11 @@
     </p:column>
 
     <p:column headerText="Start" style="text-align: center;" sortBy="#{case.startTimestamp}" sortOrder="descending">
-      <jc:datetime id="startTime" datetime="#{case.startTimestamp}" />
+      <jc:time id="startTime" datetime="#{case.startTimestamp}" />
     </p:column>
 
     <p:column headerText="End" style="text-align: center;" sortBy="#{case.endTimestamp}" responsivePriority="3">
-      <jc:datetime id="endTime" datetime="#{case.endTimestamp}" />
+      <jc:time id="endTime" datetime="#{case.endTimestamp}" />
     </p:column>
 
     <p:column styleClass="table-btn-1">

--- a/dev-workflow-ui/webContent/includes/components/personalTasksTable.xhtml
+++ b/dev-workflow-ui/webContent/includes/components/personalTasksTable.xhtml
@@ -33,11 +33,11 @@
     </p:column>
 
     <p:column headerText="Start" sortBy="#{task.startTimestamp}" sortOrder="descending" responsivePriority="2">
-      <jc:datetime id="startTime" datetime="#{task.startTimestamp}"/>
+      <jc:time id="startTime" datetime="#{task.startTimestamp}"/>
     </p:column>
 
     <p:column headerText="Expiry" sortBy="#{task.expiryTimestamp}" responsivePriority="2">
-      <jc:datetime id="expiryTime" datetime="#{task.expiryTimestamp}"/>
+      <jc:time id="expiryTime" datetime="#{task.expiryTimestamp}"/>
     </p:column>
 
     <p:column styleClass="table-btn-1" responsivePriority="2">

--- a/dev-workflow-ui/webContent/includes/components/signals/firedSignals.xhtml
+++ b/dev-workflow-ui/webContent/includes/components/signals/firedSignals.xhtml
@@ -13,7 +13,7 @@
       <h:outputText value="#{signal.signalCode}" />
     </p:column>
     <p:column headerText="Date" sortBy="#{signal.sentTimestamp}" sortOrder="descending">
-      <jc:datetime id="sentTime" datetime="#{signal.sentTimestamp}"/>
+      <jc:time id="sentTime" datetime="#{signal.sentTimestamp}"/>
     </p:column>
     <p:column headerText="Sent by" sortBy="#{signal.sentByUser}">
       <jc:user user="#{signal.sentByUser}"/>

--- a/dev-workflow-ui/webContent/includes/components/taskDetails/description.xhtml
+++ b/dev-workflow-ui/webContent/includes/components/taskDetails/description.xhtml
@@ -44,20 +44,16 @@
     <jc:user id="taskResponsible" user="#{task.activator}" />
 
     <h:outputText value="Created" />
-    <h:outputText value="#{dateTimeIvyDevWfBean.getDetailed(task.startTimestamp)}"
-      id="createdDate" />
+    <jc:datetime id="createdDate" datetime="#{task.startTimestamp}" />
 
     <h:outputText value="Expiry" />
-    <h:outputText value="#{dateTimeIvyDevWfBean.getDetailed(task.expiryTimestamp)}"
-      id="expiryDate" />
+    <jc:datetime id="expiryDate" datetime="#{task.expiryTimestamp}" />
 
     <h:outputText value="Delay date" />
-    <h:outputText value="#{dateTimeIvyDevWfBean.getDetailed(task.delayTimestamp)}"
-      id="delayDate" />
+    <jc:datetime id="delayDate" datetime="#{task.delayTimestamp}" />
 
     <h:outputText value="Completed on" />
-    <h:outputText value="#{dateTimeIvyDevWfBean.getDetailed(task.endTimestamp)}"
-      id="completedDate" />
+    <jc:datetime id="completedDate" datetime="#{task.endTimestamp}" />
 
     <h:outputText value="Description" />
     <h:outputText value="#{task.description}" id="taskDescription" />

--- a/dev-workflow-ui/webContent/includes/components/tasksTable.xhtml
+++ b/dev-workflow-ui/webContent/includes/components/tasksTable.xhtml
@@ -37,11 +37,11 @@
     </p:column>
 
     <p:column headerText="Start" style="text-align: center;" sortBy="#{task.startTimestamp}" sortOrder="descending" responsivePriority="2">
-      <jc:datetime id="startTime" datetime="#{task.startTimestamp}"/>
+      <jc:time id="startTime" datetime="#{task.startTimestamp}"/>
     </p:column>
 
     <p:column headerText="End" style="text-align: center;" sortBy="#{task.endTimestamp}" responsivePriority="3">
-      <jc:datetime id="endTime" datetime="#{task.endTimestamp}"/>
+      <jc:time id="endTime" datetime="#{task.endTimestamp}"/>
     </p:column>
 
     <p:column styleClass="table-btn-1" responsivePriority="2">

--- a/dev-workflow-ui/webContent/resources/components/time.xhtml
+++ b/dev-workflow-ui/webContent/resources/components/time.xhtml
@@ -7,7 +7,7 @@
 </cc:interface>
 
 <cc:implementation>
-  <h:outputText id="datetime" value="#{dateTimeIvyDevWfBean.getDefault(cc.attrs.datetime)}" />
-  <p:tooltip for="datetime" value="#{dateTimeIvyDevWfBean.getPrettyTime(cc.attrs.datetime)}" position="top" />
+  <h:outputText id="datetime" value="#{dateTimeIvyDevWfBean.getPrettyTime(cc.attrs.datetime)}" />
+  <p:tooltip for="datetime" value="#{dateTimeIvyDevWfBean.getDefault(cc.attrs.datetime)}" position="top" />
 </cc:implementation>
 </html>

--- a/dev-workflow-ui/webContent/view/home.xhtml
+++ b/dev-workflow-ui/webContent/view/home.xhtml
@@ -95,10 +95,10 @@
                   </p:commandLink>
                 </p:column>
                 <p:column headerText="Start" sortBy="#{task.startTimestamp}" sortOrder="descending">
-                  <jc:datetime id="startTime" datetime="#{task.startTimestamp}" />
+                  <jc:time id="startTime" datetime="#{task.startTimestamp}" />
                 </p:column>
                 <p:column headerText="Expiry" sortBy="#{task.expiryTimestamp}" responsivePriority="2">
-                  <jc:datetime id="expiryTime" datetime="#{task.expiryTimestamp}" />
+                  <jc:time id="expiryTime" datetime="#{task.expiryTimestamp}" />
                 </p:column>
                 <p:column styleClass="table-btn-1">
                   <p:link href="#{task.detailUrl}" >

--- a/dev-workflow-ui/webContent/view/notesDialog.xhtml
+++ b/dev-workflow-ui/webContent/view/notesDialog.xhtml
@@ -1,7 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:f="http://xmlns.jcp.org/jsf/core"
   xmlns:h="http://xmlns.jcp.org/jsf/html" xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
   xmlns:ic="http://ivyteam.ch/jsf/component" xmlns:p="http://primefaces.org/ui"
-  xmlns:pe="http://primefaces.org/ui/extensions">
+  xmlns:pe="http://primefaces.org/ui/extensions" xmlns:jc="http://xmlns.jcp.org/jsf/composite/components">
 <h:head>
   <f:attribute name="primefaces.THEME" value="#{ivyFreyaTheme.theme}" />
   <meta charset="utf-8" />
@@ -50,7 +50,7 @@
               </div>
               <div class="text-color-secondary">
                 <h:outputText value="#{note.writterName} • " />
-                <h:outputText value="#{dateTimeIvyDevWfBean.getDateTimeNoYear(note.creationTimestamp)}" />
+                <jc:time datetime="#{note.creationTimestamp}" />
               </div>
             </div>
           </p:column>


### PR DESCRIPTION
- renamed "datetime" component to "time" (because it shows prettytime and datetime on hover)
- new "datetime" component which shows datetime and on hover prettytime
- those components are now used on case and task details pages
- streamline "N/A" string behaviour by removing it
![image](https://github.com/user-attachments/assets/9a415c8f-0f1b-4722-85dc-b12fa752e0c9)
![image](https://github.com/user-attachments/assets/d61b31ce-e6bd-44a4-8dad-cbe33a429a42)
![image](https://github.com/user-attachments/assets/1965bdf2-ccfc-487a-aa0d-bef1c501bf1b)
![image](https://github.com/user-attachments/assets/95ba4d6b-2bf3-42d8-85aa-1b9ade5890ad)
