### PR TITLE
Reduce WebTest flakiness

### DIFF
--- a/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestCleanup.java
+++ b/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestCleanup.java
@@ -67,7 +67,7 @@ public class WebTestCleanup {
 
     loginFromTable("testuser");
     open(viewUrl("cleanup.xhtml"));
-    $(By.id("menuform:sr_home")).shouldHave(cssClass("active-menuitem"));
+    $(By.id("menuform:sr_home")).shouldHave(cssClass("active-nav-page"));
 
     loginDeveloper();
     openView("cleanup.xhtml");

--- a/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestDefaultPagesIT.java
+++ b/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestDefaultPagesIT.java
@@ -12,6 +12,7 @@ import static com.codeborne.selenide.Selenide.$;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
 
 import com.axonivy.ivy.webtest.IvyWebTest;
 import com.codeborne.selenide.Selenide;
@@ -24,6 +25,7 @@ public class WebTestDefaultPagesIT {
     loginDeveloper();
     openView("starts.xhtml");
     $(By.id("startsForm:projectStarts:globalFilter")).setValue("testDefaultPages");
+    $(By.id("startsForm:projectStarts:globalFilter")).sendKeys(Keys.ENTER);
     $(By.id("startsForm:projectStarts")).shouldHave(text("dev-workflow-ui-test-data"));
     $(byText("TestData/testDefaultPages.ivp")).shouldBe(visible).click();
     $(By.id("iFrame")).shouldBe(visible);

--- a/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestDefaultPagesIT.java
+++ b/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestDefaultPagesIT.java
@@ -39,7 +39,7 @@ public class WebTestDefaultPagesIT {
   public void testRedirectDefaultHome() {
     $(By.id("homeBtn")).shouldBe(visible).click();
     Selenide.switchTo().defaultContent();
-    $(By.id("menuform:sr_home")).shouldHave(cssClass("active-menuitem"));
+    $(By.id("menuform:sr_home")).shouldHave(cssClass("active-nav-page"));
     assertCurrentUrlContains("home.xhtml");
   }
 
@@ -47,7 +47,7 @@ public class WebTestDefaultPagesIT {
   public void testRedirectDefaultProcessStarts() {
     $(By.id("startsBtn")).shouldBe(visible).click();
     Selenide.switchTo().defaultContent();
-    $(By.id("menuform:sr_starts")).shouldHave(cssClass("active-menuitem"));
+    $(By.id("menuform:sr_starts")).shouldHave(cssClass("active-nav-page"));
     assertCurrentUrlContains("starts.xhtml");
   }
 
@@ -55,7 +55,7 @@ public class WebTestDefaultPagesIT {
   public void testRedirectDefaultTaskList() {
     $(By.id("tasksBtn")).shouldBe(visible).click();
     Selenide.switchTo().defaultContent();
-    $(By.id("menuform:sr_tasks")).shouldHave(cssClass("active-menuitem"));
+    $(By.id("menuform:sr_tasks")).shouldHave(cssClass("active-nav-page"));
     assertCurrentUrlContains("tasks.xhtml");
   }
 

--- a/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestHomeRedirect.java
+++ b/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestHomeRedirect.java
@@ -1,9 +1,11 @@
 package ch.ivyteam.ivy.project.workflow.webtest;
 
 import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.loginFromTable;
+import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.logout;
 import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.startTestProcess;
 import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.viewUrl;
 import static com.codeborne.selenide.Condition.cssClass;
+import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.open;
 
@@ -21,9 +23,10 @@ public class WebTestHomeRedirect {
     startTestProcess("1750C5211D94569D/cleanupSession.ivp");
 
     open(viewUrl("home.xhtml"));
-    $(By.id("menuform:sr_starts")).shouldHave(cssClass("active-menuitem"));
+    $(By.id("menuform:sr_home")).shouldHave(cssClass("active-nav-page"));
+
+    logout();
     open(viewUrl("home.xhtml"));
-    $(By.id("menuform:sr_starts")).shouldNotHave(cssClass("active-menuitem"));
-    $(By.id("menuform:sr_home")).shouldHave(cssClass("active-menuitem"));
+    $(By.id("loginTable")).shouldBe(visible);
   }
 }

--- a/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestHomepageIT.java
+++ b/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestHomepageIT.java
@@ -6,6 +6,7 @@ import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.loginF
 import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.openView;
 import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.startTestProcess;
 import static com.codeborne.selenide.Condition.readonly;
+import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selectors.byText;
 import static com.codeborne.selenide.Selenide.$;
@@ -27,8 +28,9 @@ public class WebTestHomepageIT {
 
     // start process to create test data
     openView("starts.xhtml");
-    $(By.id("startsForm:projectStarts:globalFilter")).setValue("case");
-    $(byText("test _ case _ map")).shouldBe(visible).click();
+    $(By.id("startsForm:projectStarts:globalFilter")).setValue("test _ case _ map");
+    $(By.id("startsForm:projectStarts:0:processStartBtn")).shouldBe(visible).click();
+    $(By.id("iFrameForm:frameTaskName")).shouldBe(text("Test Developer Workflow-UI Dialog 1"));
     $(By.id("iFrame")).shouldBe(visible);
     openView("home.xhtml");
     $(".startedProcessesCard").shouldBe(visible);

--- a/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestIntermediateEventsIT.java
+++ b/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestIntermediateEventsIT.java
@@ -38,7 +38,7 @@ public class WebTestIntermediateEventsIT {
     openView("home.xhtml");
     loginFromTable("testuser");
     open(viewUrl("intermediateEvents.xhtml"));
-    $(By.id("menuform:sr_home")).shouldHave(cssClass("active-menuitem"));
+    $(By.id("menuform:sr_home")).shouldHave(cssClass("active-nav-page"));
 
     loginDeveloper();
     openView("intermediateEvents.xhtml");

--- a/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestLoginIT.java
+++ b/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestLoginIT.java
@@ -45,7 +45,7 @@ public class WebTestLoginIT {
     logout();
     openView("home.xhtml");
     loginFromTable("testuser");
-    $(By.id("menuform:sr_home")).shouldHave(cssClass("active-menuitem"));
+    $(By.id("menuform:sr_home")).shouldHave(cssClass("active-nav-page"));
     assertCurrentUrlContains("home.xhtml");
     logout();
     $("#sessionUserName").shouldHave(text("Unknown User"));

--- a/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestSignalsIT.java
+++ b/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestSignalsIT.java
@@ -39,7 +39,7 @@ public class WebTestSignalsIT {
   public void testSignalAdminOnly() {
     loginFromTable("testuser");
     open(viewUrl("signals.xhtml"));
-    $(By.id("menuform:sr_home")).shouldHave(cssClass("active-menuitem"));
+    $(By.id("menuform:sr_home")).shouldHave(cssClass("active-nav-page"));
 
     loginDeveloper();
     openView("signals.xhtml");

--- a/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestStartsIT.java
+++ b/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestStartsIT.java
@@ -107,12 +107,12 @@ public class WebTestStartsIT {
 
     openView("tasks.xhtml");
     $(By.id("tasksForm:tasks")).find("TestTask");
-    $(By.id("menuform:sr_tasks")).shouldHave(cssClass("active-menuitem"));
+    $(By.id("menuform:sr_tasks")).shouldHave(cssClass("active-nav-page"));
     assertCurrentUrlContains("tasks.xhtml");
 
     openView("home.xhtml");
     $(By.id("startedProcesses")).find(byText("TestData/TestData.ivp")).click();
-    $(By.id("menuform:sr_home")).shouldHave(cssClass("active-menuitem"));
+    $(By.id("menuform:sr_home")).shouldHave(cssClass("active-nav-page"));
     assertCurrentUrlContains("home.xhtml");
 
     openView("tasks.xhtml");
@@ -138,7 +138,7 @@ public class WebTestStartsIT {
   public void testFrameHeaderBarSidestep() {
     openView("starts.xhtml");
     $(By.id("startsForm:projectStarts:globalFilter")).setValue("test _ case _ map");
-    $(byText("test _ case _ map")).shouldBe(visible).click();
+    $(By.id("startsForm:projectStarts:0:processStartBtn")).shouldBe(visible).click();
     $(By.id("iFrameForm:frameTaskName")).shouldHave(text("Test Developer Workflow-UI Dialog 1"));
     $(By.id("iFrameForm:sidestepsBtn")).shouldBe(visible).click();
     $(By.id("iFrameForm:sidestepMenu")).shouldBe(visible).find(By.className("ui-menuitem-link")).click();
@@ -146,7 +146,7 @@ public class WebTestStartsIT {
     Selenide.switchTo().frame("iFrame");
     $(By.id("form:proceed")).shouldBe(enabled).click();
     Selenide.switchTo().defaultContent();
-    $(By.id("menuform:sr_starts")).shouldHave(cssClass("active-menuitem"));
+    $(By.id("menuform:sr_starts")).shouldHave(cssClass("active-nav-page"));
   }
 
   @Test

--- a/dev-workflow-ui/src/ch/ivyteam/workflowui/SidebarIvyDevWfBean.java
+++ b/dev-workflow-ui/src/ch/ivyteam/workflowui/SidebarIvyDevWfBean.java
@@ -15,6 +15,14 @@ import ch.ivyteam.ivy.security.context.EngineCockpitUrlPath;
 public class SidebarIvyDevWfBean {
 
   private final String activePage;
+  private final String[] developerPages = {
+          "signals",
+          "intermediateEvents",
+          "cleanup",
+          "api-browser",
+          "statistics",
+          "webservices"
+  };
 
   public SidebarIvyDevWfBean() {
     String currentUrl = FacesContext.getCurrentInstance().getViewRoot().getViewId();
@@ -28,5 +36,12 @@ public class SidebarIvyDevWfBean {
 
   public String getCockpitPath() {
     return EngineCockpitUrlPath.toPath();
+  }
+
+  public String isDeveloperPageActive() {
+    if (isActive(developerPages)) {
+      return "active-nav-page";
+    }
+    return "";
   }
 }

--- a/dev-workflow-ui/src/ch/ivyteam/workflowui/tasks/TasksDataModel.java
+++ b/dev-workflow-ui/src/ch/ivyteam/workflowui/tasks/TasksDataModel.java
@@ -15,7 +15,6 @@ import ch.ivyteam.ivy.security.ISecurityContext;
 import ch.ivyteam.ivy.workflow.TaskState;
 import ch.ivyteam.ivy.workflow.WorkflowPriority;
 import ch.ivyteam.ivy.workflow.query.TaskQuery;
-import ch.ivyteam.workflowui.util.EngineModeUtil;
 import ch.ivyteam.workflowui.util.TaskUtil;
 import ch.ivyteam.workflowui.util.UserUtil;
 
@@ -79,7 +78,7 @@ public class TasksDataModel extends LazyDataModel<TaskModel> {
   private void checkIfShowAll(TaskQuery taskQuery) {
     if (!isShowAll()) {
       taskQuery.where().and(TaskQuery.create().where().currentUserIsInvolved());
-      if (EngineModeUtil.isDesigner() && UserUtil.isAdmin()) {
+      if (UserUtil.isAdmin()) {
         taskQuery.where().and().not(TaskQuery.create().where().activatorId().isEqual(ISecurityContext.current().users().system().getSecurityMemberId()));
       }
     }

--- a/dev-workflow-ui/src/ch/ivyteam/workflowui/tasks/TasksDataModel.java
+++ b/dev-workflow-ui/src/ch/ivyteam/workflowui/tasks/TasksDataModel.java
@@ -15,6 +15,7 @@ import ch.ivyteam.ivy.security.ISecurityContext;
 import ch.ivyteam.ivy.workflow.TaskState;
 import ch.ivyteam.ivy.workflow.WorkflowPriority;
 import ch.ivyteam.ivy.workflow.query.TaskQuery;
+import ch.ivyteam.workflowui.util.EngineModeUtil;
 import ch.ivyteam.workflowui.util.TaskUtil;
 import ch.ivyteam.workflowui.util.UserUtil;
 
@@ -78,7 +79,9 @@ public class TasksDataModel extends LazyDataModel<TaskModel> {
   private void checkIfShowAll(TaskQuery taskQuery) {
     if (!isShowAll()) {
       taskQuery.where().and(TaskQuery.create().where().currentUserIsInvolved());
-      taskQuery.where().and().not(TaskQuery.create().where().activatorId().isEqual(ISecurityContext.current().users().system().getSecurityMemberId()));
+      if (EngineModeUtil.isDesigner() && UserUtil.isAdmin()) {
+        taskQuery.where().and().not(TaskQuery.create().where().activatorId().isEqual(ISecurityContext.current().users().system().getSecurityMemberId()));
+      }
     }
   }
 

--- a/dev-workflow-ui/webContent/includes/template/sidebar.xhtml
+++ b/dev-workflow-ui/webContent/includes/template/sidebar.xhtml
@@ -10,17 +10,17 @@
     <div class="layout-menu-container">
       <h:form id="menuform">
         <pm:menu widgetVar="sidebar_menu">
-          <p:menuitem id="sr_home" value="Home" icon="si si-house-1" url="home.xhtml" containerStyleClass="#{sidebarIvyDevWfBean.isActive('home') ? 'active-menuitem' : ''}" />
-          <p:menuitem id="sr_starts" value="Processes" icon="si si-hierarchy-6 si-rotate-270" url="starts.xhtml" containerStyleClass="#{sidebarIvyDevWfBean.isActive('starts') ? 'active-menuitem' : ''}" />
-          <p:menuitem id="sr_tasks" value="Tasks" icon="si si-layout-bullets" url="tasks.xhtml" containerStyleClass="#{sidebarIvyDevWfBean.isActive('tasks') ? 'active-menuitem' : ''}" />
-          <p:menuitem id="sr_cases" value="Cases" icon="si si-task-list-approve" url="cases.xhtml" containerStyleClass="#{sidebarIvyDevWfBean.isActive('cases') ? 'active-menuitem' : ''}" />
-          <p:submenu id="sr_actions" label="Developer" icon="si si-tools-wench" rendered="#{adminIvyDevWfBean.isWorkflowAdmin()}" styleClass="#{sidebarIvyDevWfBean.isActive('signals', 'intermediateEvents', 'cleanup', 'api-browser') ? 'active-menuitem' : ''}">
-            <p:menuitem id="sr_signals" value="Signals" icon="si si-network-signal" url="signals.xhtml" styleClass="#{sidebarIvyDevWfBean.isActive('signals') ? 'active-submenu' : ''}"/>
-            <p:menuitem id="sr_intermediate_events" value="Intermediate Events" icon="si si-analytics-graph" url="intermediateEvents.xhtml" styleClass="#{sidebarIvyDevWfBean.isActive('intermediateEvents') ? 'active-submenu' : ''}"/>
-            <p:menuitem id="sr_cleanup" value="Cleanup" icon="si si-recycling-trash-bin-2" url="cleanup.xhtml" rendered="#{engineModeIvyDevWfBean.demoOrDesigner}" styleClass="#{sidebarIvyDevWfBean.isActive('cleanup') ? 'active-submenu' : ''}"/>
-            <p:menuitem id="sr_api-browser" value="API Browser" icon="si si-network-browser" url="api-browser.xhtml" styleClass="#{sidebarIvyDevWfBean.isActive('api-browser') ? 'active-submenu' : ''}"/>
-            <p:menuitem id="sr_statistics" value="Statistics" icon="si si-analytics-graph" url="statistics.xhtml" styleClass="#{sidebarIvyDevWfBean.isActive('statistics') ? 'active-submenu' : ''}"/>
-            <p:menuitem id="sr_webservices" value="Web Service" icon="si si-network-arrow" url="webservices.xhtml" styleClass="#{sidebarIvyDevWfBean.isActive('webservices') ? 'active-submenu' : ''}"/>
+          <p:menuitem id="sr_home" value="Home" icon="si si-house-1" url="home.xhtml" containerStyleClass="#{sidebarIvyDevWfBean.isActive('home') ? 'active-nav-page' : ''}" />
+          <p:menuitem id="sr_starts" value="Processes" icon="si si-hierarchy-6 si-rotate-270" url="starts.xhtml" containerStyleClass="#{sidebarIvyDevWfBean.isActive('starts') ? 'active-nav-page' : ''}" />
+          <p:menuitem id="sr_tasks" value="Tasks" icon="si si-layout-bullets" url="tasks.xhtml" containerStyleClass="#{sidebarIvyDevWfBean.isActive('tasks') ? 'active-nav-page' : ''}" />
+          <p:menuitem id="sr_cases" value="Cases" icon="si si-task-list-approve" url="cases.xhtml" containerStyleClass="#{sidebarIvyDevWfBean.isActive('cases') ? 'active-nav-page' : ''}" />
+          <p:submenu id="sr_actions" label="Developer" icon="si si-tools-wench" rendered="#{adminIvyDevWfBean.isWorkflowAdmin()}" styleClass="#{sidebarIvyDevWfBean.isDeveloperPageActive()}">
+            <p:menuitem id="sr_signals" value="Signals" icon="si si-network-signal" url="signals.xhtml" styleClass="#{sidebarIvyDevWfBean.isActive('signals') ? 'active-nav-submenu' : ''}"/>
+            <p:menuitem id="sr_intermediate_events" value="Intermediate Events" icon="si si-analytics-graph" url="intermediateEvents.xhtml" styleClass="#{sidebarIvyDevWfBean.isActive('intermediateEvents') ? 'active-nav-submenu' : ''}"/>
+            <p:menuitem id="sr_cleanup" value="Cleanup" icon="si si-recycling-trash-bin-2" url="cleanup.xhtml" rendered="#{engineModeIvyDevWfBean.demoOrDesigner}" styleClass="#{sidebarIvyDevWfBean.isActive('cleanup') ? 'active-nav-submenu' : ''}"/>
+            <p:menuitem id="sr_api-browser" value="API Browser" icon="si si-network-browser" url="api-browser.xhtml" styleClass="#{sidebarIvyDevWfBean.isActive('api-browser') ? 'active-nav-submenu' : ''}"/>
+            <p:menuitem id="sr_statistics" value="Statistics" icon="si si-analytics-graph" url="statistics.xhtml" styleClass="#{sidebarIvyDevWfBean.isActive('statistics') ? 'active-nav-submenu' : ''}"/>
+            <p:menuitem id="sr_webservices" value="Web Service" icon="si si-network-arrow" url="webservices.xhtml" styleClass="#{sidebarIvyDevWfBean.isActive('webservices') ? 'active-nav-submenu' : ''}"/>
             <p:menuitem id="sr_engine-cockpit" value="Engine Cockpit" icon="si si-cog" url="#{sidebarIvyDevWfBean.cockpitPath}"/>
           </p:submenu>
         </pm:menu>

--- a/dev-workflow-ui/webContent/resources/css/workflow-ui.css
+++ b/dev-workflow-ui/webContent/resources/css/workflow-ui.css
@@ -41,6 +41,11 @@ a > i.detail-btn {
 .details-description-label {
   opacity: 0.65;
 }
+.layout-horizontal .menu-wrapper .layout-menu-container .layout-menu > li.active-nav-page > a,
+.layout-horizontal .menu-wrapper .layout-menu-container .layout-menu > li > ul li > a.active-nav-submenu {
+  background-color: var(--primary-lighter-color);
+  color: var(--primary-color);
+}
 
 /* Tables */
 .table-header-none thead {


### PR DESCRIPTION
- Add our own css class for topbar navigation styling (primefaces likes to disappear on hover?)
- Start processes using start button instead by row click (less flaky)
- Move a bit of the sidebar navigation code to java bean
- Adjust TaskDataModel to only filter system tasks for the admin
![image](https://github.com/user-attachments/assets/aa435a1a-123b-4c79-8e93-8087180675a1)
