### PR TITLE
Potential fix for code scanning alert no. 2: Client-side URL redirect

### DIFF
--- a/dev-workflow-ui/webContent/view/frame.xhtml
+++ b/dev-workflow-ui/webContent/view/frame.xhtml
@@ -85,29 +85,23 @@
           attachUnload();
         }
 
+        const authorizedUrls = [
+          'task.xhtml',
+          'home.xhtml',
+          'tasks.xhtml',
+          'starts.xhtml',
+          'login.xhtml',
+          'loginTable.xhtml',
+          'end.xhtml'
+        ];
+
         function checkAndReturnUrl(newURL, originPage) {
-          if (newURL.includes('task.xhtml')){
-            return newURL.substring(newURL.indexOf('task.xhtml'));
+          for (let url of authorizedUrls) {
+            if (newURL.includes(url)) {
+              return url;
+            }
           }
           if (newURL.includes('?endedTaskId=')) {
-            return originPage;
-          }
-          if (newURL.endsWith('/faces/home.xhtml') || newURL.includes('DefaultApplicationHomePage.ivp') || newURL.endsWith('/app/home.xhtml')) {
-            return 'home.xhtml';
-          }
-          if (newURL.endsWith('/faces/tasks.xhtml') || newURL.includes('DefaultTaskListPage.ivp') || newURL.endsWith('/app/tasks.xhtml')) {
-            return 'tasks.xhtml';
-          }
-          if (newURL.endsWith('/faces/starts.xhtml') || newURL.includes('DefaultProcessStartListPage.ivp') || newURL.endsWith('/app/starts.xhtml')) {
-            return 'starts.xhtml';
-          }
-          if (newURL.endsWith('/faces/login.xhtml') || newURL.includes('DefaultLoginPage.ivp') || newURL.endsWith('/app/login.xhtml')) {
-            return 'login.xhtml';
-          }
-          if (newURL.endsWith('/faces/loginTable.xhtml')) {
-            return 'loginTable.xhtml';
-          }
-          if (newURL.endsWith('/faces/end.xhtml') || newURL.includes('DefaultEndPage.ivp') || newURL.endsWith('/app/end.xhtml')) {
             return originPage;
           }
           return undefined;


### PR DESCRIPTION
Potential fix for [https://github.com/axonivy/dev-workflow-ui/security/code-scanning/2](https://github.com/axonivy/dev-workflow-ui/security/code-scanning/2)

To fix the problem, we need to ensure that the redirection URL is validated against a list of authorized URLs. This can be achieved by maintaining a list of allowed URLs and checking the user-provided URL against this list before performing the redirection. If the URL is not in the list, the redirection should not occur.

1. Create a list of authorized URLs.
2. Modify the `checkAndReturnUrl` function to validate the URL against this list.
3. Ensure that only URLs from the authorized list are used for redirection.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
