### PR TITLE
XIVY-16798 Fix NPE on task redirect

### DIFF
--- a/dev-workflow-ui/src/ch/ivyteam/workflowui/tasks/TasksDetailsBean.java
+++ b/dev-workflow-ui/src/ch/ivyteam/workflowui/tasks/TasksDetailsBean.java
@@ -133,7 +133,7 @@ public class TasksDetailsBean {
   }
 
   private boolean canResume() {
-    return TaskUtil.canResume(selectedTask.getUuid());
+    return selectedTask != null && TaskUtil.canResume(selectedTask.getUuid());
   }
 
   private final EnumSet<TaskState> activeTaskStates = EnumSet.of(


### PR DESCRIPTION
If a POST ajax request is happening on the task detail page, and after that the task is directly started, the originUrl will be evaluated based on this POST request. The problem here is that this request does not include the query parameters, so the task id is no longer there and therefore there is no selected task.