### PR TITLE
XIVY-14746 Statistics resolution selection

### DIFF
--- a/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestStatisticsIT.java
+++ b/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestStatisticsIT.java
@@ -32,7 +32,7 @@ class WebTestStatisticsIT {
     $("h4").shouldHave(text("Statistics"));
     $(By.id("statisticsForm")).shouldBe(visible);
 
-    $(By.id("statisticsForm")).shouldHave(text("Time range:"));
+    $(By.id("statisticsForm")).shouldHave(text("Time range"));
     var timeRangeDropdown = $(By.id("statisticsForm:timeDuration"));
     timeRangeDropdown.shouldBe(visible);
   }

--- a/dev-workflow-ui/cms/cms_de.yaml
+++ b/dev-workflow-ui/cms/cms_de.yaml
@@ -227,6 +227,7 @@ statistics:
   allTasks: Alle Aufgaben
   casesByState: Fälle nach Status
   casesStatistics: Fall Statistik
+  chartResolution: Diagramm Auflösung
   notEnoughData: Nicht genügend Daten
   tasksByState: Aufgaben nach Status
   tasksStatistics: Aufgaben Statistik
@@ -239,6 +240,12 @@ statistics:
     last7d: Letzte Woche
     last90d: Letzte 3 Monate
     today: Heute
+  resolutions:
+    hour: stündlich
+    hour6: alle 6 Stunden
+    day: täglich
+    week: wöchentlich
+    month: monatlich
   topCaseCreators: Top Fall Ersteller
   topTaskWorkers: Top Aufgaben Bearbeiter
 switchUser:

--- a/dev-workflow-ui/cms/cms_en.yaml
+++ b/dev-workflow-ui/cms/cms_en.yaml
@@ -227,6 +227,7 @@ statistics:
   allTasks: All Tasks
   casesByState: Cases by State
   casesStatistics: Cases Statistics
+  chartResolution: Chart resolution
   notEnoughData: Not enough data available
   tasksByState: Tasks by State
   tasksStatistics: Task Statistics
@@ -239,6 +240,12 @@ statistics:
     last7d: Last week
     last90d: Last 3 months
     today: Today
+  resolutions:
+    hour: hourly
+    hour6: every 6 hours
+    day: daily
+    week: weekly
+    month: monthly
   topCaseCreators: Top Case Creators
   topTaskWorkers: Top Task Workers
 switchUser:

--- a/dev-workflow-ui/src/ch/ivyteam/workflowui/statistics/Resolution.java
+++ b/dev-workflow-ui/src/ch/ivyteam/workflowui/statistics/Resolution.java
@@ -1,0 +1,9 @@
+package ch.ivyteam.workflowui.statistics;
+
+public interface Resolution {
+  String HOUR = "hour";
+  String HOUR6 = "hour6";
+  String DAY = "day";
+  String WEEK = "week";
+  String MONTH = "month";
+}

--- a/dev-workflow-ui/src/ch/ivyteam/workflowui/statistics/TimeDuration.java
+++ b/dev-workflow-ui/src/ch/ivyteam/workflowui/statistics/TimeDuration.java
@@ -1,0 +1,11 @@
+package ch.ivyteam.workflowui.statistics;
+
+public interface TimeDuration {
+  String TODAY = "today";
+  String LAST_24H = "24h";
+  String LAST_7D = "7d/d";
+  String LAST_30D = "30d/d";
+  String LAST_90D = "90d/d";
+  String LAST_365D = "365d/d";
+  String ALL_TIME = "all";
+}

--- a/dev-workflow-ui/webContent/view/statistics.xhtml
+++ b/dev-workflow-ui/webContent/view/statistics.xhtml
@@ -12,7 +12,7 @@
             <h4 class="m-0">#{ivy.cm.co('/sidebar/statistics')}</h4>
           </div>
           <div class="flex align-items-center">
-            <h:outputText value="#{ivy.cm.co('/statistics/timeRange')}:" />
+            <h:outputText value="#{ivy.cm.co('/statistics/timeRange')}" />
             <p:selectOneMenu id="timeDuration" value="#{statisticsBean.timeDuration}" styleClass="ml-2">
               <p:ajax update="statisticsForm" event="valueChange" />
               <f:selectItem itemLabel="#{ivy.cm.co('/statistics/timeRanges/today')}" itemValue="today" />
@@ -22,6 +22,14 @@
               <f:selectItem itemLabel="#{ivy.cm.co('/statistics/timeRanges/last90d')}" itemValue="90d/d" />
               <f:selectItem itemLabel="#{ivy.cm.co('/statistics/timeRanges/last365d')}" itemValue="365d/d" />
               <f:selectItem itemLabel="#{ivy.cm.co('/statistics/timeRanges/allTime')}" itemValue="all" />
+            </p:selectOneMenu>
+            <h:outputText value="—" styleClass="ml-2" />
+            <p:selectOneMenu id="chartResolution" value="#{statisticsBean.chartResolution}" styleClass="ml-2"
+              disabled="#{!statisticsBean.resolutionDropdownVisible}"
+              title="#{!statisticsBean.resolutionDropdownVisible ? 'Only one resolution available for this time range' : ''}">
+              <p:ajax update="statisticsForm" event="valueChange" />
+              <f:selectItems value="#{statisticsBean.validResolutions}" var="resolution"
+                itemLabel="#{ivy.cm.co('/statistics/resolutions/'.concat(resolution))}" itemValue="#{resolution}" />
             </p:selectOneMenu>
           </div>
         </div>


### PR DESCRIPTION
I think this is the best working solution. It doesnt make sense to allow all resolutions for all time ranges (time range year + resolution day would have 365 points)
@ivy-cst 

Right now the options are:


| time range | resolutions | dropdown state |
|------------|----------------------|----------------|
| Today/24h  | Hour                 | Disabled (1 option) |
| 7 days     | 6 Hours, Day         | Enabled (2 options) |
| 30 days    | Day, Week            | Enabled (2 options) |
| 90 days    | Day, Week            | Enabled (2 options) |
| 365 days   | Week, Month          | Enabled (2 options) |
| All time   | Month                | Disabled (1 option) |


[edit] new images:
![Screenshot From 2025-07-09 13-33-06](https://github.com/user-attachments/assets/e6e9546b-91e2-4f8a-b24b-068a8d5ea6e0)

![image](https://github.com/user-attachments/assets/306bc1b9-fd75-4830-b475-b1eac61f1807)
![Screenshot From 2025-07-09 11-51-36](https://github.com/user-attachments/assets/9299369f-7e2a-4292-8b08-d7903e302325)


