### PR TITLE
Fix role styling on profile page

### DIFF
--- a/dev-workflow-ui/webContent/view/profile.xhtml
+++ b/dev-workflow-ui/webContent/view/profile.xhtml
@@ -33,7 +33,7 @@
               <div class="mt-3 mb-2">#{ivy.cm.co('/common/roles')}</div>
               <div id="roles" class="flex flex-wrap">
                 <ui:repeat var="role" value="#{profileBean.roles}">
-                  <div class="surface-50 my-1 mr-2 p-2 w-min border-round-lg">
+                  <div class="surface-50 my-1 mr-2 p-2 border-round-lg">
                     <h:outputText id="roles" value="#{role}" />
                   </div>
                 </ui:repeat>


### PR DESCRIPTION
noticed this by accident

before: 
<img width="540" height="164" alt="Screenshot From 2025-09-11 09-40-55" src="https://github.com/user-attachments/assets/d2965ef5-d9ba-403e-990f-6c911b6b1415" />

new: 
<img width="540" height="164" alt="Screenshot From 2025-09-11 09-41-01" src="https://github.com/user-attachments/assets/09cc29e8-92d7-4243-a45f-22c71e61d47c" />

