### PR TITLE
Add guard for case.xhtml, redirect if no case view access

### DIFF
--- a/dev-workflow-ui-test-data/processes/TestData.p.json
+++ b/dev-workflow-ui-test-data/processes/TestData.p.json
@@ -201,7 +201,7 @@
         "labelOffset" : { "x" : 5, "y" : 38 }
       },
       "connect" : [
-        { "id" : "f17", "to" : "f11", "via" : [ { "x" : 352, "y" : 352 } ] }
+        { "id" : "f17", "to" : "f70" }
       ]
     }, {
       "id" : "f18",
@@ -715,5 +715,24 @@
       "visual" : {
         "at" : { "x" : 1016, "y" : 160 }
       }
+    }, {
+      "id" : "f70",
+      "type" : "UserTask",
+      "name" : "TestDialog",
+      "config" : {
+        "dialog" : "ch.ivyteam.ivy.project.workflow.TestDialog1:start(ch.ivyteam.ivy.project.workflow.Data)",
+        "task" : {
+          "name" : "task created in UserTask during test:signal:complete test"
+        },
+        "case" : {
+          "name" : "case created in UserTask during test:signal:complete test"
+        }
+      },
+      "visual" : {
+        "at" : { "x" : 224, "y" : 352 }
+      },
+      "connect" : [
+        { "id" : "f71", "to" : "f11", "via" : [ { "x" : 352, "y" : 352 } ], "color" : "default" }
+      ]
     } ]
 }

--- a/dev-workflow-ui-test-data/processes/TestData.p.json
+++ b/dev-workflow-ui-test-data/processes/TestData.p.json
@@ -201,7 +201,7 @@
         "labelOffset" : { "x" : 5, "y" : 38 }
       },
       "connect" : [
-        { "id" : "f17", "to" : "f70" }
+        { "id" : "f17", "to" : "f11", "via" : [ { "x" : 352, "y" : 352 } ] }
       ]
     }, {
       "id" : "f18",
@@ -715,24 +715,5 @@
       "visual" : {
         "at" : { "x" : 1016, "y" : 160 }
       }
-    }, {
-      "id" : "f70",
-      "type" : "UserTask",
-      "name" : "TestDialog",
-      "config" : {
-        "dialog" : "ch.ivyteam.ivy.project.workflow.TestDialog1:start(ch.ivyteam.ivy.project.workflow.Data)",
-        "task" : {
-          "name" : "task created in UserTask during test:signal:complete test"
-        },
-        "case" : {
-          "name" : "case created in UserTask during test:signal:complete test"
-        }
-      },
-      "visual" : {
-        "at" : { "x" : 224, "y" : 352 }
-      },
-      "connect" : [
-        { "id" : "f71", "to" : "f11", "via" : [ { "x" : 352, "y" : 352 } ], "color" : "default" }
-      ]
     } ]
 }

--- a/dev-workflow-ui/src/ch/ivyteam/workflowui/cases/CasesDetailsIvyDevWfBean.java
+++ b/dev-workflow-ui/src/ch/ivyteam/workflowui/cases/CasesDetailsIvyDevWfBean.java
@@ -25,6 +25,7 @@ import ch.ivyteam.workflowui.document.DocumentModel;
 import ch.ivyteam.workflowui.tasks.TaskModel;
 import ch.ivyteam.workflowui.tasks.WorkflowEventModel;
 import ch.ivyteam.workflowui.util.CaseUtil;
+import ch.ivyteam.workflowui.util.RedirectUtil;
 import ch.ivyteam.workflowui.util.ResponseHelper;
 import ch.ivyteam.workflowui.util.TaskUtil;
 import ch.ivyteam.workflowui.util.ViewerUtil;
@@ -167,5 +168,15 @@ public class CasesDetailsIvyDevWfBean {
 
   public String getProcessPreviewLink() {
     return processPreviewLink;
+  }
+  
+  public void redirectIfCantAccess() {
+    if (!canAccess()) {
+      RedirectUtil.redirect();
+    }
+  }
+
+  private boolean canAccess() {
+	return selectedCase != null && CaseUtil.canAccess(selectedCase);
   }
 }

--- a/dev-workflow-ui/src/ch/ivyteam/workflowui/cases/CasesDetailsIvyDevWfBean.java
+++ b/dev-workflow-ui/src/ch/ivyteam/workflowui/cases/CasesDetailsIvyDevWfBean.java
@@ -169,7 +169,7 @@ public class CasesDetailsIvyDevWfBean {
   public String getProcessPreviewLink() {
     return processPreviewLink;
   }
-  
+
   public void redirectIfCantAccess() {
     if (!canAccess()) {
       RedirectUtil.redirect();
@@ -177,6 +177,6 @@ public class CasesDetailsIvyDevWfBean {
   }
 
   private boolean canAccess() {
-	return selectedCase != null && CaseUtil.canAccess(selectedCase);
+    return selectedCase != null && CaseUtil.canAccess(selectedCase);
   }
 }

--- a/dev-workflow-ui/src/ch/ivyteam/workflowui/util/CaseUtil.java
+++ b/dev-workflow-ui/src/ch/ivyteam/workflowui/util/CaseUtil.java
@@ -55,35 +55,33 @@ public class CaseUtil {
   }
 
   public static boolean canAccess(ICase caze) {
-    Ivy.log().info("caze: " + caze);
+//    Ivy.log().info("caze: " + caze);
     if (caze == null) {
       return false;
     }
     var session = ISession.current();
-    Ivy.log().info("session: " + session);
+//    Ivy.log().info("session: " + session);
     if (session == null) {
       return false;
     }
-    Ivy.log().info("session user: " + session.getSessionUser());
+//    Ivy.log().info("session user: " + session.getSessionUser());
     if (session.getSessionUser() == null) {
       return false;
     }
     if (caze instanceof Case) {
-      Ivy.log().info("caze is instanceof Case");
-//      return ((Case) caze).involved().members().stream().anyMatch(u -> u.isMember(session, true));
-      var allMembers = ((Case) caze).involved().members();
-      Ivy.log().info("allMembers:" + allMembers);
-      allMembers.stream().forEach(u -> {
-        Ivy.log().info("Involved member " + u);
-        if (u.isMember(session, true)) {
-          Ivy.log().info("Involved member is session user");
-        }
-      });
+      return ((Case) caze).involved().members().stream().anyMatch(u -> u.isMember(session, true));
 
-      return allMembers.stream().anyMatch(u -> u.isMember(session, true));
+      //      Ivy.log().info("caze is instanceof Case");
+//      var allMembers = ((Case) caze).involved().members();
+//      Ivy.log().info("allMembers:" + allMembers);
+//      allMembers.stream().forEach(u -> {
+//        Ivy.log().info("Involved member " + u);
+//        if (u.isMember(session, true)) {
+//          Ivy.log().info("Involved member is session user");
+//        }
+//      });
+//      return allMembers.stream().anyMatch(u -> u.isMember(session, true));
 
-//      var members = ((Case) caze).involved().members();
-//      Stream.of().anyMatch(u -> u.isMember(session, true));
     } else {
       Ivy.log().info("caze is NOT instanceof Case");
       // TODO: Should this case even be handled? If yes with an Exception?

--- a/dev-workflow-ui/src/ch/ivyteam/workflowui/util/CaseUtil.java
+++ b/dev-workflow-ui/src/ch/ivyteam/workflowui/util/CaseUtil.java
@@ -52,11 +52,11 @@ public class CaseUtil {
     LastSessionStarts.current().add(startable);
     startable.execute();
   }
-  
+
   public static boolean canAccess(ICase caze) {
     if (caze == null) {
-	  return false;
-	}
+      return false;
+    }
     var session = ISession.current();
     if (session == null) {
       return false;
@@ -70,6 +70,6 @@ public class CaseUtil {
     } else {
       // TODO: Should this case even be handled? If yes with an Exception?
       return false;
-    }  
+    }
   }
 }

--- a/dev-workflow-ui/src/ch/ivyteam/workflowui/util/CaseUtil.java
+++ b/dev-workflow-ui/src/ch/ivyteam/workflowui/util/CaseUtil.java
@@ -8,7 +8,9 @@ import org.apache.commons.lang3.StringUtils;
 
 import ch.ivyteam.ivy.casemap.runtime.model.ICaseMap;
 import ch.ivyteam.ivy.casemap.runtime.repo.restricted.ICaseMapBusinessCase;
+import ch.ivyteam.ivy.security.ISession;
 import ch.ivyteam.ivy.workflow.ICase;
+import ch.ivyteam.ivy.workflow.internal.caze.Case;
 import ch.ivyteam.ivy.workflow.ITask;
 import ch.ivyteam.ivy.workflow.IWorkflowContext;
 import ch.ivyteam.workflowui.cases.CaseModel;
@@ -49,5 +51,25 @@ public class CaseUtil {
     var startable = new StartableModel(businessCase.getStartedFrom());
     LastSessionStarts.current().add(startable);
     startable.execute();
+  }
+  
+  public static boolean canAccess(ICase caze) {
+    if (caze == null) {
+	  return false;
+	}
+    var session = ISession.current();
+    if (session == null) {
+      return false;
+    }
+    var currentUser = session.getSessionUser();
+    if (currentUser == null) {
+      return false;
+    }
+    if (caze instanceof Case) {
+      return ((Case) caze).involved().members().stream().anyMatch(u -> u.isMember(session, true));
+    } else {
+      // TODO: Should this case even be handled? If yes with an Exception?
+      return false;
+    }  
   }
 }

--- a/dev-workflow-ui/src/ch/ivyteam/workflowui/util/CaseUtil.java
+++ b/dev-workflow-ui/src/ch/ivyteam/workflowui/util/CaseUtil.java
@@ -8,7 +8,6 @@ import org.apache.commons.lang3.StringUtils;
 
 import ch.ivyteam.ivy.casemap.runtime.model.ICaseMap;
 import ch.ivyteam.ivy.casemap.runtime.repo.restricted.ICaseMapBusinessCase;
-import ch.ivyteam.ivy.environment.Ivy;
 import ch.ivyteam.ivy.security.ISession;
 import ch.ivyteam.ivy.workflow.ICase;
 import ch.ivyteam.ivy.workflow.internal.caze.Case;
@@ -55,35 +54,19 @@ public class CaseUtil {
   }
 
   public static boolean canAccess(ICase caze) {
-//    Ivy.log().info("caze: " + caze);
     if (caze == null) {
       return false;
     }
     var session = ISession.current();
-//    Ivy.log().info("session: " + session);
     if (session == null) {
       return false;
     }
-//    Ivy.log().info("session user: " + session.getSessionUser());
     if (session.getSessionUser() == null) {
       return false;
     }
     if (caze instanceof Case) {
       return ((Case) caze).involved().members().stream().anyMatch(u -> u.isMember(session, true));
-
-      //      Ivy.log().info("caze is instanceof Case");
-//      var allMembers = ((Case) caze).involved().members();
-//      Ivy.log().info("allMembers:" + allMembers);
-//      allMembers.stream().forEach(u -> {
-//        Ivy.log().info("Involved member " + u);
-//        if (u.isMember(session, true)) {
-//          Ivy.log().info("Involved member is session user");
-//        }
-//      });
-//      return allMembers.stream().anyMatch(u -> u.isMember(session, true));
-
     } else {
-      Ivy.log().info("caze is NOT instanceof Case");
       // TODO: Should this case even be handled? If yes with an Exception?
       return false;
     }

--- a/dev-workflow-ui/src/ch/ivyteam/workflowui/util/CaseUtil.java
+++ b/dev-workflow-ui/src/ch/ivyteam/workflowui/util/CaseUtil.java
@@ -79,7 +79,7 @@ public class CaseUtil {
           Ivy.log().info("Involved member is session user");
         }
       });
-      
+
       return allMembers.stream().anyMatch(u -> u.isMember(session, true));
 
 //      var members = ((Case) caze).involved().members();

--- a/dev-workflow-ui/src/ch/ivyteam/workflowui/util/CaseUtil.java
+++ b/dev-workflow-ui/src/ch/ivyteam/workflowui/util/CaseUtil.java
@@ -8,6 +8,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import ch.ivyteam.ivy.casemap.runtime.model.ICaseMap;
 import ch.ivyteam.ivy.casemap.runtime.repo.restricted.ICaseMapBusinessCase;
+import ch.ivyteam.ivy.environment.Ivy;
 import ch.ivyteam.ivy.security.ISession;
 import ch.ivyteam.ivy.workflow.ICase;
 import ch.ivyteam.ivy.workflow.internal.caze.Case;
@@ -54,19 +55,37 @@ public class CaseUtil {
   }
 
   public static boolean canAccess(ICase caze) {
+    Ivy.log().info("caze: " + caze);
     if (caze == null) {
       return false;
     }
     var session = ISession.current();
+    Ivy.log().info("session: " + session);
     if (session == null) {
       return false;
     }
+    Ivy.log().info("session user: " + session.getSessionUser());
     if (session.getSessionUser() == null) {
       return false;
     }
     if (caze instanceof Case) {
-      return ((Case) caze).involved().members().stream().anyMatch(u -> u.isMember(session, true));
+      Ivy.log().info("caze is instanceof Case");
+//      return ((Case) caze).involved().members().stream().anyMatch(u -> u.isMember(session, true));
+      var allMembers = ((Case) caze).involved().members();
+      Ivy.log().info("allMembers:" + allMembers);
+      allMembers.stream().forEach(u -> {
+        Ivy.log().info("Involved member " + u);
+        if (u.isMember(session, true)) {
+          Ivy.log().info("Involved member is session user");
+        }
+      });
+      
+      return allMembers.stream().anyMatch(u -> u.isMember(session, true));
+
+//      var members = ((Case) caze).involved().members();
+//      Stream.of().anyMatch(u -> u.isMember(session, true));
     } else {
+      Ivy.log().info("caze is NOT instanceof Case");
       // TODO: Should this case even be handled? If yes with an Exception?
       return false;
     }

--- a/dev-workflow-ui/src/ch/ivyteam/workflowui/util/CaseUtil.java
+++ b/dev-workflow-ui/src/ch/ivyteam/workflowui/util/CaseUtil.java
@@ -64,11 +64,12 @@ public class CaseUtil {
     if (session.getSessionUser() == null) {
       return false;
     }
+    if (PermissionsUtil.isAdmin()) {
+      return true;
+    }
     if (caze instanceof Case) {
       return ((Case) caze).involved().members().stream().anyMatch(u -> u.isMember(session, true));
-    } else {
-      // TODO: Should this case even be handled? If yes with an Exception?
-      return false;
     }
+    return false;
   }
 }

--- a/dev-workflow-ui/src/ch/ivyteam/workflowui/util/CaseUtil.java
+++ b/dev-workflow-ui/src/ch/ivyteam/workflowui/util/CaseUtil.java
@@ -61,8 +61,7 @@ public class CaseUtil {
     if (session == null) {
       return false;
     }
-    var currentUser = session.getSessionUser();
-    if (currentUser == null) {
+    if (session.getSessionUser() == null) {
       return false;
     }
     if (caze instanceof Case) {

--- a/dev-workflow-ui/webContent/view/case.xhtml
+++ b/dev-workflow-ui/webContent/view/case.xhtml
@@ -13,7 +13,7 @@
   <ui:composition template="../includes/template/template.xhtml">
     <ui:define name="content">
       <f:event type="preRenderView" listener="#{casesDetailsIvyDevWfBean.redirectIfCantAccess}" />
-      
+
       <div class="layout-dashboard">
         <div class="grid">
           <div class="col-12 lg:col-8">

--- a/dev-workflow-ui/webContent/view/case.xhtml
+++ b/dev-workflow-ui/webContent/view/case.xhtml
@@ -12,6 +12,8 @@
 
   <ui:composition template="../includes/template/template.xhtml">
     <ui:define name="content">
+      <f:event type="preRenderView" listener="#{casesDetailsIvyDevWfBean.redirectIfCantAccess}" />
+      
       <div class="layout-dashboard">
         <div class="grid">
           <div class="col-12 lg:col-8">


### PR DESCRIPTION
**Changes**
- Prevent not logged in user or user without case access to navigate to `case.xhtml` by adding a guard before rendering
- Solution analog to the already implemented guard in `TaskUtil.java` and `TasksDetailsIvyDevWfBean.java`

**To do**
- [x] WebTest `caseProcessViewerCanOpen` in `/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestSignalsIT.java` breaks because case link click from signals table redirects to home now. Must be fixed by setting appropriate roles for test user? Or is this the missing admin permission?
- [x] Screenshots different sizes?

**To discuss**
- Same solution will not be possible on master, since access to `ch.ivyteam.ivy.workflow.internal.caze.Case.involved()` is restricted