### PR TITLE
XIVY-19259 fix: permission check on intermediate event detail page > master

### DIFF
--- a/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebDocuScreenshots.java
+++ b/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebDocuScreenshots.java
@@ -68,9 +68,6 @@ class WebDocuScreenshots {
     openView("starts.xhtml");
     takeScreenshot("workflow-ui-starts", new Dimension(SCREENSHOT_WIDTH, 800));
 
-    openView("cleanup.xhtml");
-    takeScreenshot("workflow-ui-cleanup", new Dimension(SCREENSHOT_WIDTH, 500));
-
     openView("signals.xhtml");
     $(By.id("signalForm:signalCodeInput_input")).sendKeys("Screenshot data signal");
     $(By.id("signalForm:signalBtn")).shouldBe(enabled).click();
@@ -104,6 +101,10 @@ class WebDocuScreenshots {
     $(By.id("statisticsForm:taskStatisticsChart_canvas")).shouldBe(visible);
     $(By.id("statisticsForm:topCaseCreatorsChart_canvas")).shouldBe(visible);
     takeScreenshot("workflow-ui-statistics", new Dimension(SCREENSHOT_WIDTH, 800));
+
+    startTestProcess("1783B19164F69B78/devMode.ivp");
+    openView("cleanup.xhtml");
+    takeScreenshot("workflow-ui-cleanup", new Dimension(SCREENSHOT_WIDTH, 500));
   }
 
   private void takeScreenshot(String fileName, Dimension size) {

--- a/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestCleanup.java
+++ b/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestCleanup.java
@@ -4,8 +4,10 @@ import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.loginD
 import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.loginFromTable;
 import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.open;
 import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.openView;
+import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.openViewNoAssertion;
 import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.startTestProcess;
 import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.viewUrl;
+import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.assertCurrentUrlContains;
 import static com.codeborne.selenide.Condition.cssClass;
 import static com.codeborne.selenide.Condition.disabled;
 import static com.codeborne.selenide.Condition.enabled;
@@ -55,12 +57,12 @@ class WebTestCleanup {
 
   @Test
   @Order(1)
-  void noCleanupIfNotDevMode() {
-    openView("cleanup.xhtml");
-    $(By.id("cleanupForm:cleanupBtn")).shouldBe(disabled);
+  void redirectIfNotDevMode() {
+    openViewNoAssertion("cleanup.xhtml");
+    assertCurrentUrlContains("home.xhtml");
     startTestProcess("1783B19164F69B78/designerStandard.ivp");
-    openView("cleanup.xhtml");
-    $(By.id("cleanupForm:cleanupBtn")).shouldBe(disabled);
+    openViewNoAssertion("cleanup.xhtml");
+    assertCurrentUrlContains("home.xhtml");
   }
 
   @Test

--- a/dev-workflow-ui/src/ch/ivyteam/workflowui/PermissionsBean.java
+++ b/dev-workflow-ui/src/ch/ivyteam/workflowui/PermissionsBean.java
@@ -17,7 +17,7 @@ public class PermissionsBean implements Serializable {
   }
 
   public boolean isDevModeAndAdmin() {
-    return PermissionsUtil.isDevMode() && isAdmin();
+    return PermissionsUtil.isDevModeAndAdmin();
   }
 
   public boolean isAdmin() {

--- a/dev-workflow-ui/src/ch/ivyteam/workflowui/login/LoginBean.java
+++ b/dev-workflow-ui/src/ch/ivyteam/workflowui/login/LoginBean.java
@@ -90,14 +90,20 @@ public class LoginBean implements Serializable {
     UserUtil.redirectIfNotAdmin();
   }
 
-  public void redirectIfNotDevMode() {
+  public void redirectIfNotDemoOrDevMode() {
     if (!PermissionsUtil.isDemoOrDevMode()) {
       RedirectUtil.redirect();
     }
   }
 
-  public void redirectIfNotDevModeOrAdmin() {
+  public void redirectIfNotDemoDevModeOrAdmin() {
     if (!PermissionsUtil.isDemoDevModeOrAdmin()) {
+      RedirectUtil.redirect();
+    }
+  }
+
+  public void redirectIfNotDevModeAndAdmin() {
+    if (!PermissionsUtil.isDevModeAndAdmin()) {
       RedirectUtil.redirect();
     }
   }

--- a/dev-workflow-ui/src/ch/ivyteam/workflowui/util/PermissionsUtil.java
+++ b/dev-workflow-ui/src/ch/ivyteam/workflowui/util/PermissionsUtil.java
@@ -25,6 +25,10 @@ public class PermissionsUtil {
     return isDemoOrDevMode() && isAdmin();
   }
 
+  public static boolean isDevModeAndAdmin() {
+    return isDevMode() && isAdmin();
+  }
+
   public static boolean isAdmin() {
     return hasPermission(IPermission.TASK_READ_ALL) && hasPermission(IPermission.CASE_READ_ALL);
   }

--- a/dev-workflow-ui/webContent/view/api-browser.xhtml
+++ b/dev-workflow-ui/webContent/view/api-browser.xhtml
@@ -6,7 +6,7 @@
 <h:body>
   <ui:composition template="../includes/template/template.xhtml">
     <ui:define name="content">
-      <f:event type="preRenderView" listener="#{loginBean.redirectIfNotDevModeOrAdmin}" />
+      <f:event type="preRenderView" listener="#{loginBean.redirectIfNotDemoDevModeOrAdmin}" />
 
       <div class="card">
         <div class="flex align-items-center mb-3">

--- a/dev-workflow-ui/webContent/view/cleanup.xhtml
+++ b/dev-workflow-ui/webContent/view/cleanup.xhtml
@@ -6,7 +6,7 @@
 <h:body>
   <ui:composition template="../includes/template/template.xhtml">
     <ui:define name="content">
-      <f:event type="preRenderView" listener="#{loginBean.redirectIfNotAdmin}" />
+      <f:event type="preRenderView" listener="#{loginBean.redirectIfNotDevModeAndAdmin}" />
 
       <div class="card">
         <h4 class="m-0">#{ivy.cm.co('/sidebar/cleanup')}</h4>
@@ -20,8 +20,7 @@
             </p:selectManyCheckbox>
 
             <p:commandButton id="cleanupBtn" value="#{ivy.cm.co('/sidebar/cleanup')}" icon="ti ti-recycle"
-              actionListener="#{cleanupBean.cleanup}" update="growl"
-              disabled="#{!permissionsBean.devModeAndAdmin}" />
+              actionListener="#{cleanupBean.cleanup}" update="growl" />
           </p:panelGrid>
         </h:form>
       </div>

--- a/dev-workflow-ui/webContent/view/intermediate-event.xhtml
+++ b/dev-workflow-ui/webContent/view/intermediate-event.xhtml
@@ -11,6 +11,8 @@
 
   <ui:composition template="../includes/template/template.xhtml">
     <ui:define name="content">
+      <f:event type="preRenderView" listener="#{loginBean.redirectIfNotDemoDevModeOrAdmin}" />
+
       <ui:param name="intermediateElement" value="#{intermediateEventDetailsBean.selectedIntermediateElement}"></ui:param>
 
       <div class="layout-dashboard">

--- a/dev-workflow-ui/webContent/view/intermediate-events.xhtml
+++ b/dev-workflow-ui/webContent/view/intermediate-events.xhtml
@@ -6,7 +6,7 @@
 <h:body>
   <ui:composition template="../includes/template/template.xhtml">
     <ui:define name="content">
-      <f:event type="preRenderView" listener="#{loginBean.redirectIfNotDevModeOrAdmin}" />
+      <f:event type="preRenderView" listener="#{loginBean.redirectIfNotDemoDevModeOrAdmin}" />
 
       <div class="card">
         <h4 class="mb-3">#{ivy.cm.co('/intermediateEvents/intermediateEventsBeans')}</h4>

--- a/dev-workflow-ui/webContent/view/signals.xhtml
+++ b/dev-workflow-ui/webContent/view/signals.xhtml
@@ -6,7 +6,7 @@
 <h:body>
   <ui:composition template="../includes/template/template.xhtml">
     <ui:define name="content">
-      <f:event type="preRenderView" listener="#{loginBean.redirectIfNotDevModeOrAdmin}" />
+      <f:event type="preRenderView" listener="#{loginBean.redirectIfNotDemoDevModeOrAdmin}" />
 
       <div class="layout-dashboard">
         <div class="grid">

--- a/dev-workflow-ui/webContent/view/statistics.xhtml
+++ b/dev-workflow-ui/webContent/view/statistics.xhtml
@@ -5,7 +5,7 @@
 <h:body>
   <ui:composition template="../includes/template/template.xhtml">
     <ui:define name="content">
-      <f:event type="preRenderView" listener="#{loginBean.redirectIfNotDevModeOrAdmin}" />
+      <f:event type="preRenderView" listener="#{loginBean.redirectIfNotDemoDevModeOrAdmin}" />
       <h:form id="statisticsForm">
         <div class="flex m-3 justify-content-between">
           <div class="flex align-items-center">

--- a/dev-workflow-ui/webContent/view/switch-user.xhtml
+++ b/dev-workflow-ui/webContent/view/switch-user.xhtml
@@ -10,7 +10,7 @@
 <h:body>
   <ui:composition template="../includes/template/template.xhtml">
     <ui:define name="content">
-      <f:event type="preRenderView" listener="#{loginBean.redirectIfNotDevMode}" />
+      <f:event type="preRenderView" listener="#{loginBean.redirectIfNotDemoOrDevMode}" />
 
       <h:panelGroup layout="block" styleClass="static-message" rendered="#{!loginBean.loggedIn}">
         <p:staticMessage severity="warn" summary="Warning" detail="#{ivy.cm.co('/switchUser/needLogin')}"

--- a/dev-workflow-ui/webContent/view/webservices.xhtml
+++ b/dev-workflow-ui/webContent/view/webservices.xhtml
@@ -6,7 +6,7 @@
 <h:body>
   <ui:composition template="../includes/template/template.xhtml">
     <ui:define name="content">
-      <f:event type="preRenderView" listener="#{loginBean.redirectIfNotDevModeOrAdmin}" />
+      <f:event type="preRenderView" listener="#{loginBean.redirectIfNotDemoDevModeOrAdmin}" />
 
       <h:form id="webServicesForm">
         <p:growl id="growl" showDetail="true" />


### PR DESCRIPTION
Also tighten permission check on cleanup page to align with "Developer" menu in sidebar and rename some methods to better reflect what they actually check.