### PR TITLE
XIVY-19259 fix: permission check on intermediate event detail page > 12

### DIFF
--- a/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebDocuScreenshots.java
+++ b/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebDocuScreenshots.java
@@ -64,9 +64,6 @@ class WebDocuScreenshots {
     openView("starts.xhtml");
     takeScreenshot("workflow-ui-starts", new Dimension(SCREENSHOT_WIDTH, 800));
 
-    openView("cleanup.xhtml");
-    takeScreenshot("workflow-ui-cleanup", new Dimension(SCREENSHOT_WIDTH, 800));
-
     openView("signals.xhtml");
     $(By.id("signalForm:signalCodeInput_input")).sendKeys("Screenshot data signal");
     $(By.id("signalForm:signalBtn")).shouldBe(enabled).click();
@@ -100,6 +97,10 @@ class WebDocuScreenshots {
     $(By.id("taskStatisticsChart_canvas")).shouldBe(visible);
     $(By.id("topCaseCreatorsChart_canvas")).shouldBe(visible);
     takeScreenshot("workflow-ui-statistics", new Dimension(SCREENSHOT_WIDTH, 800));
+
+    startTestProcess("1783B19164F69B78/designerEmbedded.ivp");
+    openView("cleanup.xhtml");
+    takeScreenshot("workflow-ui-cleanup", new Dimension(SCREENSHOT_WIDTH, 800));
   }
 
   private void takeScreenshot(String fileName, Dimension size) {

--- a/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestCleanup.java
+++ b/dev-workflow-ui-web-test/src_test/ch/ivyteam/ivy/project/workflow/webtest/WebTestCleanup.java
@@ -1,9 +1,11 @@
 package ch.ivyteam.ivy.project.workflow.webtest;
 
+import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.assertCurrentUrlContains;
 import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.loginDeveloper;
 import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.loginFromTable;
 import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.open;
 import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.openView;
+import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.openViewNoAssertion;
 import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.startTestProcess;
 import static ch.ivyteam.ivy.project.workflow.webtest.util.WorkflowUiUtil.viewUrl;
 import static com.codeborne.selenide.Condition.cssClass;
@@ -12,6 +14,8 @@ import static com.codeborne.selenide.Condition.enabled;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selenide.$;
+
+import java.util.Map;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -52,12 +56,12 @@ class WebTestCleanup {
 
   @Test
   @Order(1)
-  void noCleanupIfNotDevMode() {
-    openView("cleanup.xhtml");
-    $(By.id("clanupForm:cleanupBtn")).shouldBe(disabled);
+  void redirectIfNotDevMode() {
+    openViewNoAssertion("cleanup.xhtml", Map.of());
+    assertCurrentUrlContains("home.xhtml");
     startTestProcess("1783B19164F69B78/designerStandard.ivp");
-    openView("cleanup.xhtml");
-    $(By.id("clanupForm:cleanupBtn")).shouldBe(disabled);
+    openViewNoAssertion("cleanup.xhtml", Map.of());
+    assertCurrentUrlContains("home.xhtml");
   }
 
   @Test

--- a/dev-workflow-ui/src/ch/ivyteam/workflowui/PermissionsBean.java
+++ b/dev-workflow-ui/src/ch/ivyteam/workflowui/PermissionsBean.java
@@ -15,7 +15,7 @@ public class PermissionsBean {
   }
 
   public boolean isDevModeAndAdmin() {
-    return PermissionsUtil.isDevMode() && isAdmin();
+    return PermissionsUtil.isDevModeAndAdmin();
   }
 
   public boolean isAdmin() {

--- a/dev-workflow-ui/src/ch/ivyteam/workflowui/login/LoginIvyDevWfBean.java
+++ b/dev-workflow-ui/src/ch/ivyteam/workflowui/login/LoginIvyDevWfBean.java
@@ -87,14 +87,20 @@ public class LoginIvyDevWfBean {
     UserUtil.redirectIfNotAdmin();
   }
 
-  public void redirectIfNotDevMode() {
+  public void redirectIfNotDemoOrDevMode() {
     if (!PermissionsUtil.isDemoOrDevMode()) {
       RedirectUtil.redirect();
     }
   }
 
-  public void redirectIfNotDevModeOrAdmin() {
+  public void redirectIfNotDemoDevModeOrAdmin() {
     if (!PermissionsUtil.isDemoDevModeOrAdmin()) {
+      RedirectUtil.redirect();
+    }
+  }
+
+  public void redirectIfNotDevModeAndAdmin() {
+    if (!PermissionsUtil.isDevModeAndAdmin()) {
       RedirectUtil.redirect();
     }
   }

--- a/dev-workflow-ui/src/ch/ivyteam/workflowui/util/PermissionsUtil.java
+++ b/dev-workflow-ui/src/ch/ivyteam/workflowui/util/PermissionsUtil.java
@@ -25,6 +25,10 @@ public class PermissionsUtil {
     return isDemoOrDevMode() && isAdmin();
   }
 
+  public static boolean isDevModeAndAdmin() {
+    return isDevMode() && isAdmin();
+  }
+
   public static boolean isAdmin() {
     return hasPermission(IPermission.TASK_READ_ALL) & hasPermission(IPermission.CASE_READ_ALL);
   }

--- a/dev-workflow-ui/webContent/view/api-browser.xhtml
+++ b/dev-workflow-ui/webContent/view/api-browser.xhtml
@@ -6,7 +6,7 @@
 <h:body>
   <ui:composition template="../includes/template/template.xhtml">
     <ui:define name="content">
-      <f:event type="preRenderView" listener="#{loginIvyDevWfBean.redirectIfNotDevModeOrAdmin}" />
+      <f:event type="preRenderView" listener="#{loginIvyDevWfBean.redirectIfNotDemoDevModeOrAdmin}" />
 
       <div class="card">
         <div class="flex align-items-center mb-3">

--- a/dev-workflow-ui/webContent/view/cleanup.xhtml
+++ b/dev-workflow-ui/webContent/view/cleanup.xhtml
@@ -6,7 +6,7 @@
 <h:body>
   <ui:composition template="../includes/template/template.xhtml">
     <ui:define name="content">
-      <f:event type="preRenderView" listener="#{loginIvyDevWfBean.redirectIfNotAdmin}" />
+      <f:event type="preRenderView" listener="#{loginIvyDevWfBean.redirectIfNotDevModeAndAdmin}" />
 
       <div class="card">
         <h4 class="m-0">Cleanup</h4>
@@ -23,8 +23,7 @@
               value="#{cleanupIvyDevWfBean.identityProviderTokens}" itemLabel="All identity provider tokens" />
             <p:selectBooleanCheckbox id="dataCaches" value="#{cleanupIvyDevWfBean.dataCaches}" itemLabel="Data caches" />
             <p:commandButton id="cleanupBtn" value="Cleanup" icon="si si-recycling-trash-bin-2 "
-              actionListener="#{cleanupIvyDevWfBean.cleanup}" update="growl"
-              disabled="#{!permissionsBean.devModeAndAdmin}" />
+              actionListener="#{cleanupIvyDevWfBean.cleanup}" update="growl" />
           </p:panelGrid>
         </h:form>
       </div>

--- a/dev-workflow-ui/webContent/view/intermediateEventDetails.xhtml
+++ b/dev-workflow-ui/webContent/view/intermediateEventDetails.xhtml
@@ -10,6 +10,8 @@
 
   <ui:composition template="../includes/template/template.xhtml">
     <ui:define name="content">
+      <f:event type="preRenderView" listener="#{loginIvyDevWfBean.redirectIfNotDemoDevModeOrAdmin}" />
+
       <ui:param name="intermediateElement" value="#{intermediateEventDetailsIvyDevWfBean.selectedIntermediateElement}"></ui:param>
 
       <div class="layout-dashboard">

--- a/dev-workflow-ui/webContent/view/intermediateEvents.xhtml
+++ b/dev-workflow-ui/webContent/view/intermediateEvents.xhtml
@@ -6,7 +6,7 @@
 <h:body>
   <ui:composition template="../includes/template/template.xhtml">
     <ui:define name="content">
-      <f:event type="preRenderView" listener="#{loginIvyDevWfBean.redirectIfNotDevModeOrAdmin}" />
+      <f:event type="preRenderView" listener="#{loginIvyDevWfBean.redirectIfNotDemoDevModeOrAdmin}" />
 
       <div class="card">
         <h4 class="mb-3">Intermediate Event Beans</h4>

--- a/dev-workflow-ui/webContent/view/loginTable.xhtml
+++ b/dev-workflow-ui/webContent/view/loginTable.xhtml
@@ -9,7 +9,7 @@
   </f:metadata>
   <ui:composition template="../includes/template/template.xhtml">
     <ui:define name="content">
-      <f:event type="preRenderView" listener="#{loginIvyDevWfBean.redirectIfNotDevMode}" />
+      <f:event type="preRenderView" listener="#{loginIvyDevWfBean.redirectIfNotDemoOrDevMode}" />
 
       <h:panelGroup layout="block" styleClass="static-message" rendered="#{!loginIvyDevWfBean.loggedIn}">
         <p:staticMessage severity="warn" summary="Warning" detail="You need to login to access that page"

--- a/dev-workflow-ui/webContent/view/signals.xhtml
+++ b/dev-workflow-ui/webContent/view/signals.xhtml
@@ -6,7 +6,7 @@
 <h:body>
   <ui:composition template="../includes/template/template.xhtml">
     <ui:define name="content">
-      <f:event type="preRenderView" listener="#{loginIvyDevWfBean.redirectIfNotDevModeOrAdmin}" />
+      <f:event type="preRenderView" listener="#{loginIvyDevWfBean.redirectIfNotDemoDevModeOrAdmin}" />
 
       <div class="layout-dashboard">
         <div class="grid">

--- a/dev-workflow-ui/webContent/view/statistics.xhtml
+++ b/dev-workflow-ui/webContent/view/statistics.xhtml
@@ -5,7 +5,7 @@
 <h:body>
   <ui:composition template="../includes/template/template.xhtml">
     <ui:define name="content">
-      <f:event type="preRenderView" listener="#{loginIvyDevWfBean.redirectIfNotDevModeOrAdmin}" />
+      <f:event type="preRenderView" listener="#{loginIvyDevWfBean.redirectIfNotDemoDevModeOrAdmin}" />
       <div class="flex align-items-center m-3">
         <h4 class="m-0">Statistics</h4>
       </div>

--- a/dev-workflow-ui/webContent/view/webservices.xhtml
+++ b/dev-workflow-ui/webContent/view/webservices.xhtml
@@ -6,7 +6,7 @@
 <h:body>
   <ui:composition template="../includes/template/template.xhtml">
     <ui:define name="content">
-      <f:event type="preRenderView" listener="#{loginIvyDevWfBean.redirectIfNotDevModeOrAdmin}" />
+      <f:event type="preRenderView" listener="#{loginIvyDevWfBean.redirectIfNotDemoDevModeOrAdmin}" />
 
       <h:form id="webServicesForm">
         <p:growl id="growl" showDetail="true" />


### PR DESCRIPTION
Also tighten permission check on cleanup page to align with "Developer" menu in sidebar and rename some methods to better reflect what they actually check.